### PR TITLE
Fixed CSRF token encryption

### DIFF
--- a/masonite/auth/Csrf.py
+++ b/masonite/auth/Csrf.py
@@ -16,7 +16,7 @@ class Csrf(object):
         """
 
         token = bytes(binascii.b2a_hex(os.urandom(15))).decode('utf-8')
-        self.request.cookie('csrf_token', token)
+        self.request.cookie('csrf_token', token, encrypt=False)
         return token
 
     def verify_csrf_token(self, token):
@@ -24,7 +24,7 @@ class Csrf(object):
         Verify if csrf token is valid
         """
 
-        if self.request.get_cookie('csrf_token') == token:
+        if self.request.get_cookie('csrf_token', decrypt=False) == token:
             return True
         else:
             return False

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'masonite.contracts',
         'masonite.helpers',
     ],
-    version='1.4.0',
+    version='1.4.1',
     install_requires=[
         'validator.py==1.2.5',
         'cryptography==2.1.4',

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -15,7 +15,7 @@ middleware = container.resolve(CsrfMiddleware)
 middleware.before()
 
 def test_middleware_sets_csrf_cookie():
-    assert request.get_cookie('csrf_token')
+    assert request.get_cookie('csrf_token', decrypt=False)
 
 def test_middleware_shares_view():
     assert 'csrf_field' in container.make('ViewClass').dictionary


### PR DESCRIPTION
CSRF tokens should not be encrypted because it prohibits multiple projects running on the same server because each project has a different cookie and tries to decrypt the CSRF token with the wrong secret key it was encrypted with.