### PR TITLE
added support for application/json type requests

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -50,6 +50,9 @@ class Request(Extendable):
         if self.is_not_get_request():
             if isinstance(self.params, str):
                 return parse_qs(self.params)[param][0]
+            
+            if isinstance(self.params, dict):
+                return self.params[param]
 
             if not self.params[param].filename:
                 return self.params[param].value

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -374,3 +374,11 @@ def test_hidden_form_request_method_changes_request_method():
     assert request.environ['REQUEST_METHOD'] == 'PUT'
 
 
+def test_get_json_input():
+    json_wsgi = wsgi_request
+    json_wsgi['REQUEST_METHOD'] = 'POST'
+    request_obj = Request(json_wsgi)
+    request_obj.params = {'payload': {'id': 1}}
+
+    assert request_obj.input('payload') == {'id': 1}
+

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -3,7 +3,7 @@ from pydoc import locate
 
 from masonite.request import Request
 from masonite.app import App
-from masonite.routes import Get
+from masonite.routes import Get, Route
 from masonite.helpers.time import cookie_expire_time
 
 
@@ -374,11 +374,22 @@ def test_hidden_form_request_method_changes_request_method():
     assert request.environ['REQUEST_METHOD'] == 'PUT'
 
 
+class MockWsgiInput():
+
+    def read(self, value):
+        return '{"id": 1}'
+
+
 def test_get_json_input():
     json_wsgi = wsgi_request
     json_wsgi['REQUEST_METHOD'] = 'POST'
-    request_obj = Request(json_wsgi)
-    request_obj.params = {'payload': {'id': 1}}
+    json_wsgi['CONTENT_TYPE'] = 'application/json'
+    json_wsgi['QUERY_STRING'] = ''
+    json_wsgi['wsgi.input'] = MockWsgiInput()
 
+    Route(json_wsgi)
+    request_obj = Request(json_wsgi)
+
+    assert isinstance(request_obj.params, dict)
     assert request_obj.input('payload') == {'id': 1}
 


### PR DESCRIPTION
This PR will add application/json support. The current way Masonite gets input data (post get and post using cgi.FieldStorage) currently does not support application/json (for some dumb reason) so if the server receives an application/form-data it will be fine but if it receives an application/json it will not be able to get it.

Now masonite will be able to handle this and stores the json receives in a payload input:

```python
request().input('payload') # returns a dictionary of the JSON request sent to the server
```