### PR TITLE
readded serve command and fixed commands dropping

### DIFF
--- a/masonite/commands/ServeCommand.py
+++ b/masonite/commands/ServeCommand.py
@@ -1,0 +1,19 @@
+from cleo import Command
+from subprocess import call
+
+class ServeCommand(Command):
+    """
+    Run the Masonite server
+
+    serve
+        {--port=8000 : Specify which port to run the server}
+        {--host=127.0.0.1 : Specify which ip address to run the server}
+    """
+
+
+    def handle(self):
+        try:
+            call(["waitress-serve", '--port', self.option('port'), "--host", self.option('host'), "wsgi:application"])
+        except:
+            self.line('')
+            self.comment('Server aborted!')

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -2,7 +2,9 @@
 from masonite.provider import ServiceProvider
 from masonite.request import Request
 from masonite.routes import Route
+
 from config import storage
+
 from routes import web, api
 
 from masonite.commands.AuthCommand import AuthCommand
@@ -19,6 +21,7 @@ from masonite.commands.MigrateRollbackCommand import MigrateRollbackCommand
 from masonite.commands.ModelCommand import ModelCommand
 from masonite.commands.ProviderCommand import ProviderCommand
 from masonite.commands.ViewCommand import ViewCommand
+from masonite.commands.ServeCommand import ServeCommand
 
 
 class AppProvider(ServiceProvider):
@@ -46,6 +49,7 @@ class AppProvider(ServiceProvider):
         self.app.bind('MasoniteModelCommand', ModelCommand())
         self.app.bind('MasoniteProviderCommand', ProviderCommand())
         self.app.bind('MasoniteViewCommand', ViewCommand())
+        self.app.bind('MasoniteServeCommand', ServeCommand())
 
     def boot(self, Environ, Request, Route):
         self.app.bind('Headers', [])

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -124,16 +124,19 @@ class BaseHttpRoute:
             if mod[0].startswith('/'):
                 self.module_location = '.'.join(mod[0].replace('/', '').split('.')[0:-1])
 
-            # Import the module
-            module = importlib.import_module(
-                '{0}.'.format(self.module_location) + get_controller)      
+            try:
+                # Import the module
+                module = importlib.import_module(
+                    '{0}.'.format(self.module_location) + get_controller)  
+                # Get the controller from the module
+                controller = getattr(module, get_controller)
 
-            # Get the controller from the module
-            controller = getattr(module, get_controller)
-
-            # Get the view from the controller
-            view = getattr(controller(), mod[1])
-            self.output = view
+                # Get the view from the controller
+                view = getattr(controller(), mod[1])
+                self.output = view
+            except Exception as e:
+                print('\033[93mWarning in routes/web.py!', e, '\033[0m')
+  
         else:
             self.output = output
         self.route_url = route

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 from masonite.routes import Route
 from masonite.request import Request
 from masonite.routes import Get, Post, Put, Patch, Delete
+import pytest
 
 
 wsgi_request = {
@@ -75,3 +76,6 @@ def test_route_url_list():
 def test_route_gets_controllers():
     assert Get().route('test/url', 'TestController@show')
     assert Get().route('test/url', '/app.http.test_controllers.TestController@show')
+
+def test_route_doesnt_break_on_incorrect_controller():
+    assert Get().route('test/url', 'BreakController@show')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,6 @@
 from masonite.routes import Route
 from masonite.request import Request
 from masonite.routes import Get, Post, Put, Patch, Delete
-import pytest
 
 
 wsgi_request = {


### PR DESCRIPTION
I'm not too happy with this fix. We'll need to do some refactoring to pretty up the code base a bit. But moving the commands into the framework proved to have a major downside. If there was an issue with the controllers, it would throw an error like usual but it would also close down the container .. where the commands are. So if you made a mistake in your routes/web.py file then you wouldn't have access to the command line