### PR TITLE
 Creating a controller should not have to type Controller at the end #34

### DIFF
--- a/masonite/commands/AuthCommand.py
+++ b/masonite/commands/AuthCommand.py
@@ -1,12 +1,13 @@
-from cleo import Command
 import os
 import shutil
+
+from cleo import Command
 
 
 class AuthCommand(Command):
     """
     Creates an authentication system
-    
+
     auth
     """
 

--- a/masonite/commands/CommandCommand.py
+++ b/masonite/commands/CommandCommand.py
@@ -1,5 +1,5 @@
-from cleo import Command
 import os
+from cleo import Command
 
 
 class CommandCommand(Command):

--- a/masonite/commands/ControllerCommand.py
+++ b/masonite/commands/ControllerCommand.py
@@ -9,10 +9,15 @@ class ControllerCommand(Command):
     controller
         {name : Name of the controller you would like to create}
         {--r|--resource : Create a controller as a resource}
+        {--e|--exact : For add the name controller without `Controller` text}
     """
 
     def handle(self):
         controller = self.argument('name')
+
+        if not self.option('exact'):
+            controller = controller + "Controller"
+
         if os.path.isfile('app/http/controllers/{0}.py'.format(controller)):
             self.error('{0} Controller Exists!'.format(controller))
         else:

--- a/masonite/commands/InstallCommand.py
+++ b/masonite/commands/InstallCommand.py
@@ -1,7 +1,9 @@
-from cleo import Command
-from subprocess import call
 import os
 import shutil
+from subprocess import call
+
+from cleo import Command
+
 
 class InstallCommand(Command):
     """

--- a/masonite/commands/JobCommand.py
+++ b/masonite/commands/JobCommand.py
@@ -1,6 +1,5 @@
-from cleo import Command
 import os
-from cryptography.fernet import Fernet
+from cleo import Command
 
 
 class JobCommand(Command):

--- a/masonite/commands/KeyCommand.py
+++ b/masonite/commands/KeyCommand.py
@@ -1,5 +1,4 @@
 from cleo import Command
-import os
 from cryptography.fernet import Fernet
 
 

--- a/masonite/commands/MakeMigrationCommand.py
+++ b/masonite/commands/MakeMigrationCommand.py
@@ -1,6 +1,5 @@
-from cleo import Command
-import os
 from subprocess import call
+from cleo import Command
 
 
 class MakeMigrationCommand(Command):

--- a/masonite/commands/MigrateCommand.py
+++ b/masonite/commands/MigrateCommand.py
@@ -1,8 +1,10 @@
-from cleo import Command
 import os
 import sys
-from masonite.packages import add_venv_site_packages
 from subprocess import check_output
+
+from cleo import Command
+
+from masonite.packages import add_venv_site_packages
 
 
 class MigrateCommand(Command):
@@ -20,7 +22,6 @@ class MigrateCommand(Command):
             self.comment('This command must be ran inside of the root of a Masonite project directory')
 
         from wsgi import container
-        
 
         migration_directory = ['databases/migrations']
         for key, value in container.providers.items():
@@ -40,5 +41,5 @@ class MigrateCommand(Command):
                     output.replace('OK', '<info>OK</info>') \
                     .replace('Migrated', '<info>Migrated</info><fg=cyan>') + '</>'
                 )
-            except:
+            except Exception:
                 pass

--- a/masonite/commands/MigrateRefreshCommand.py
+++ b/masonite/commands/MigrateRefreshCommand.py
@@ -1,6 +1,4 @@
 from cleo import Command
-import os
-from subprocess import check_output
 
 
 class MigrateRefreshCommand(Command):

--- a/masonite/commands/MigrateResetCommand.py
+++ b/masonite/commands/MigrateResetCommand.py
@@ -1,8 +1,9 @@
-from cleo import Command
 import os
 import sys
-from masonite.packages import  add_venv_site_packages
-from subprocess import check_output
+
+from cleo import Command
+
+from masonite.packages import add_venv_site_packages
 
 
 class MigrateResetCommand(Command):
@@ -20,7 +21,6 @@ class MigrateResetCommand(Command):
         except ImportError:
             self.comment(
                 'This command must be ran inside of the root of a Masonite project directory')
-
 
         # Get any migration files from the Service Container
         migration_directory = ['databases/migrations']
@@ -51,17 +51,16 @@ class MigrateResetCommand(Command):
                 try:
                     migrator.reset(migration_directory)
 
-                except:
+                except Exception:
                     pass
 
                 if migrator.get_notes():
                     notes += migrator.get_notes()
 
-
         # Show notes from the migrator
         self.line('')
         for note in notes:
-            if not 'Nothing to rollback.' in note:
+            if not ('Nothing to rollback.' in note):
                 self.line(note)
         if not notes:
             self.info('Nothing to rollback')

--- a/masonite/commands/MigrateRollbackCommand.py
+++ b/masonite/commands/MigrateRollbackCommand.py
@@ -1,8 +1,9 @@
-from cleo import Command
 import os
 import sys
+
+from cleo import Command
+
 from masonite.packages import add_venv_site_packages
-from subprocess import check_output
 
 
 class MigrateRollbackCommand(Command):
@@ -50,5 +51,5 @@ class MigrateRollbackCommand(Command):
                 migrator.rollback(migration)
                 for note in migrator.get_notes():
                     self.line(note)
-            except:
+            except Exception:
                 pass

--- a/masonite/commands/ModelCommand.py
+++ b/masonite/commands/ModelCommand.py
@@ -1,5 +1,5 @@
-from cleo import Command
 import os
+from cleo import Command
 
 
 class ModelCommand(Command):

--- a/masonite/commands/ProviderCommand.py
+++ b/masonite/commands/ProviderCommand.py
@@ -1,6 +1,5 @@
-from cleo import Command
 import os
-from cryptography.fernet import Fernet
+from cleo import Command
 
 
 class ProviderCommand(Command):

--- a/masonite/commands/ServeCommand.py
+++ b/masonite/commands/ServeCommand.py
@@ -1,5 +1,6 @@
-from cleo import Command
 from subprocess import call
+from cleo import Command
+
 
 class ServeCommand(Command):
     """
@@ -10,10 +11,12 @@ class ServeCommand(Command):
         {--host=127.0.0.1 : Specify which ip address to run the server}
     """
 
-
     def handle(self):
         try:
-            call(["waitress-serve", '--port', self.option('port'), "--host", self.option('host'), "wsgi:application"])
-        except:
+            call([
+                "waitress-serve", '--port', self.option('port'),
+                "--host", self.option('host'), "wsgi:application"
+            ])
+        except Exception:
             self.line('')
             self.comment('Server aborted!')

--- a/masonite/commands/ViewCommand.py
+++ b/masonite/commands/ViewCommand.py
@@ -1,7 +1,6 @@
-from cleo import Command
-from subprocess import call
 import os
-import shutil
+from cleo import Command
+
 
 class ViewCommand(Command):
     """


### PR DESCRIPTION
Two commit in this PR:

Creating a controller should not have to type Controller at the end #34
And Fix pep8 in folder commands.