### PR TITLE
moved creating of Jinja environment

### DIFF
--- a/masonite/view.py
+++ b/masonite/view.py
@@ -29,11 +29,7 @@ class View:
         self.cache_type = None
 
         self.template = None
-        self.env = Environment(
-            loader=PackageLoader('resources', 'templates'),
-            autoescape=select_autoescape(['html', 'xml']),
-            extensions=['jinja2.ext.loopcontrols']
-        )
+
 
     def render(self, template, dictionary={}):
         """
@@ -54,6 +50,12 @@ class View:
             
             self.env = Environment(
                 loader=loader,
+                autoescape=select_autoescape(['html', 'xml']),
+                extensions=['jinja2.ext.loopcontrols']
+            )
+        else:
+            self.env = Environment(
+                loader=PackageLoader('resources', 'templates'),
                 autoescape=select_autoescape(['html', 'xml']),
                 extensions=['jinja2.ext.loopcontrols']
             )


### PR DESCRIPTION
Closes #95 

The problem was that the exception handler itself was overwriting the environment creating on the init method. Now the environment is created as needed on each request.