### PR TITLE
fixed postgres and sqlite password byte issue

### DIFF
--- a/masonite/snippets/auth/controllers/RegisterController.py
+++ b/masonite/snippets/auth/controllers/RegisterController.py
@@ -17,9 +17,9 @@ class RegisterController(object):
     def store(self, Request):
         ''' Register a new user '''
         # register the user
-        password = bcrypt.hashpw(
-                bytes(Request.input('password'), 'utf-8'), bcrypt.gensalt()
-            )
+        password = bytes(bcrypt.hashpw(
+            bytes(Request.input('password'), 'utf-8'), bcrypt.gensalt()
+        )).decode('utf-8')
 
         auth.AUTH['model'].create(
             name=Request.input('name'),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'masonite.contracts',
         'masonite.helpers',
     ],
-    version='1.6.2',
+    version='1.6.3',
     install_requires=[
         'validator.py==1.2.5',
         'cryptography==2.2.2',


### PR DESCRIPTION
Closes https://github.com/MasoniteFramework/masonite/issues/84

Apparently Mysql will automatically convert bytes to a string and Postgres does not. Fixed this issue by converting the password back into a string after it has been hashed / encrypted