### PR TITLE
controller constructors are now resolved by container

### DIFF
--- a/app/http/controllers/ControllerTest.py
+++ b/app/http/controllers/ControllerTest.py
@@ -1,0 +1,7 @@
+class ControllerTest:
+
+    def __init__(self, Request):
+        self.request = Request
+
+    def show(self):
+        return self.request

--- a/app/http/controllers/TestController.py
+++ b/app/http/controllers/TestController.py
@@ -1,4 +1,4 @@
 class TestController:
 
-    def show():
+    def show(self):
         pass

--- a/masonite/providers/RouteProvider.py
+++ b/masonite/providers/RouteProvider.py
@@ -110,7 +110,11 @@ class RouteProvider(ServiceProvider):
                 if not request.redirect_url:
                     Request.status('200 OK')
 
-                    response = self.app.resolve(route.output)
+                    # Resolve Controller Constructor
+                    controller = self.app.resolve(route.controller)
+
+                    # Resolve Controller Method
+                    response = self.app.resolve(getattr(controller, route.controller_method))
 
                     if isinstance(response, View):
                         response = response.rendered_template

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -111,36 +111,43 @@ class BaseHttpRoute:
 
     def route(self, route, output):
         """ Loads the route into the class """
-
-        # If the output specified is a string controller
-        if isinstance(output, str):
-            mod = output.split('@') 
-
-            # Gets the controller name from the output parameter
-            # This is used to add support for additional modules
-            # like 'LoginController' and 'Auth.LoginController'
-            get_controller = mod[0].split('.')[-1]
-
-            # If trying to get an absolute path
-            if mod[0].startswith('/'):
-                self.module_location = '.'.join(mod[0].replace('/', '').split('.')[0:-1])
-
-            try:
-                # Import the module
-                module = importlib.import_module(
-                    '{0}.'.format(self.module_location) + get_controller)  
-                # Get the controller from the module
-                controller = getattr(module, get_controller)
-
-                # Get the view from the controller
-                view = getattr(controller(), mod[1])
-                self.output = view
-            except Exception as e:
-                print('\033[93mWarning in routes/web.py!', e, '\033[0m')
-        else:
-            self.output = output
+        self._find_controller(output)
         self.route_url = route
         return self
+    
+    def _find_controller(self, controller):
+        # If the output specified is a string controller
+        if isinstance(controller, str):
+            mod = controller.split('@')
+        
+        else:
+            if controller is None:
+                return None
+            fully_qualified_name = controller.__qualname__
+            mod = fully_qualified_name.split('.')
+
+        # Gets the controller name from the output parameter
+        # This is used to add support for additional modules
+        # like 'LoginController' and 'Auth.LoginController'
+        get_controller = mod[0].split('.')[-1]
+
+        # If trying to get an absolute path
+        if mod[0].startswith('/'):
+            self.module_location = '.'.join(
+                mod[0].replace('/', '').split('.')[0:-1])
+
+        try:
+            # Import the module
+            module = importlib.import_module(
+                '{0}.'.format(self.module_location) + get_controller)
+            # Get the controller from the module
+            self.controller = getattr(module, get_controller)
+
+            # Set the controller method on class. This is a string
+            self.controller_method = mod[1]
+
+        except Exception as e:
+            print('\033[93mWarning in routes/web.py!', e, '\033[0m')
 
     def domain(self, domain):
         self.required_domain = domain

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,5 +1,8 @@
 from masonite.app import App
 from masonite.controllers import Controller
+from masonite.helpers.routes import get
+from app.http.controllers.ControllerTest import ControllerTest
+from masonite.request import Request
 
 
 def test_controller_loads_app():
@@ -8,3 +11,29 @@ def test_controller_loads_app():
 
     controller = Controller().load_app(app)
     assert controller.app.providers == {'object': object}
+
+
+def test_string_controller_constructor_resolves_container():
+    app = App()
+    app.bind('Request', Request)
+
+    # Create the route
+    route = get('/url', 'ControllerTest@show')
+
+    # Resolve the controller constructor
+    controller = app.resolve(route.controller)
+
+    # Resolve the method
+    response = app.resolve(getattr(controller, route.controller_method))
+
+    assert isinstance(route.controller, ControllerTest.__class__)
+    assert route.controller_method == 'show'
+    assert isinstance(response, Request.__class__)
+
+
+def test_object_controller_constructor_resolves_container():
+    app = App()
+    app.bind('Request', Request)
+
+    # Create the route
+    route = get('/url', ControllerTest.show)


### PR DESCRIPTION
Closes #108 

This PR adds the feature of controller constructors being resolved by the container. This will improve how large controllers can be abstracted. It allows some dependencies to be loaded into the controller itself through the constructor before hitting a method. We can now have something like:

```python
class Controller:
    def __init__(self, Request):
        self.request = Request

    def show(self, Broadcast):
        self.request.user()
```

This also changes how object controllers (not string controllers) are passed. Previously we had something like this:

```python
from app.http.controllers.SomeController import SomeController

ROUTES = [
    get('url', SomeController().show)
]
```

notice that we instantiated the `SomeController`. We obviously can't do that anymore so now we simply don't instantiate anything:

```python
from app.http.controllers.SomeController import SomeController

ROUTES = [
    get('/url', SomeController.show)
]
```

What we do now is get the `.__qualname__` which returns a string like `SomeController.show` then we pop the `.` and parse just like a string controller using almost the same exact logic