### PR TITLE
fixed redirect url showing infinite loop

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -322,14 +322,14 @@ class Request(Extendable):
 
         # Iterate over the list
         for url in split_url:
-
-            # if the url contains a parameter variable like @id:int
-            if '@' in url:
-                url = url.replace('@', '').replace(
-                    ':int', '').replace(':string', '')
-                compiled_url += str(self.param(url)) + '/'
-            else:
-                compiled_url += url + '/'
+            if url:
+                # if the url contains a parameter variable like @id:int
+                if '@' in url:
+                    url = url.replace('@', '').replace(
+                        ':int', '').replace(':string', '')
+                    compiled_url += str(self.param(url)) + '/'
+                else:
+                    compiled_url += url + '/'
 
         # The loop isn't perfect and may have an unwanted trailing slash
         if compiled_url.endswith('/') and not self.redirect_url.endswith('/'):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'masonite.contracts',
         'masonite.helpers',
     ],
-    version='1.6.4',
+    version='1.6.5',
     install_requires=[
         'validator.py==1.2.5',
         'cryptography==2.2.2',

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -204,6 +204,15 @@ def test_redirect_compiles_url():
 
     assert request.compile_route_to_url() == '/test/url'
 
+def test_redirect_compiles_url_with_1_slash():
+    app = App()
+    app.bind('Request', REQUEST)
+    request = app.make('Request').load_app(app)
+
+    request.redirect('/')
+
+    assert request.compile_route_to_url() == '/'
+
 
 def test_redirect_compiles_url_with_multiple_slashes():
     app = App()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -200,7 +200,7 @@ def test_redirect_compiles_url():
     app.bind('Request', REQUEST)
     request = app.make('Request').load_app(app)
 
-    request.redirect('test/url')
+    request.redirect('/test/url')
 
     assert request.compile_route_to_url() == '/test/url'
 


### PR DESCRIPTION
This issue only happened when redirecting to a `/`:

```python
Request.redirect('/')
```

The reason for this bug was that the request class was compiling down the url and since it always prepended a forward slash, it ended up compiling down to: `//` which threw a redirection error