### PR TITLE
Add the tinker command

### DIFF
--- a/masonite/commands/TinkerCommand.py
+++ b/masonite/commands/TinkerCommand.py
@@ -1,0 +1,29 @@
+import code
+import sys
+from cleo import Command
+
+BANNER = """Masonite Python {} Console
+This interactive console has the following things imported:
+    container as 'app'
+
+Type `exit()` to exit."""
+
+
+class TinkerCommand(Command):
+    """
+    Run a python shell with the container pre-loaded.
+
+    tinker
+    """
+
+    def handle(self):
+        from wsgi import container
+
+        version = "{}.{}.{}".format(
+            sys.version_info.major,
+            sys.version_info.minor,
+            sys.version_info.micro
+        )
+        banner = BANNER.format(version)
+
+        code.interact(banner=banner, local={"app": container})

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -13,6 +13,7 @@ from masonite.commands.MigrateRollbackCommand import MigrateRollbackCommand
 from masonite.commands.ModelCommand import ModelCommand
 from masonite.commands.ProviderCommand import ProviderCommand
 from masonite.commands.ServeCommand import ServeCommand
+from masonite.commands.TinkerCommand import TinkerCommand
 from masonite.commands.ViewCommand import ViewCommand
 from masonite.exception_handler import ExceptionHandler
 from masonite.hook import Hook
@@ -52,6 +53,7 @@ class AppProvider(ServiceProvider):
         self.app.bind('MasoniteProviderCommand', ProviderCommand())
         self.app.bind('MasoniteViewCommand', ViewCommand())
         self.app.bind('MasoniteServeCommand', ServeCommand())
+        self.app.bind('MasoniteTinkerCommand', TinkerCommand())
 
     def boot(self, Environ, Request, Route):
         self.app.bind('Headers', [])


### PR DESCRIPTION
Added this out of inspiration. I've based this off of develop so that we may have more discussion and push it out with the 2.0 release.

In essence, the `craft tinker` command is nothing more special than a python console with the container pre-loaded as a variable `app`. What is nice about it is that it allows us to more easily tinker around with the internals of the application either for testing or for seeding information before creating the store routes in our app. For instance you could do the following to retrieve all users.

```
>>> User = app.make('User')
>>> user = User.all()
>>> for user in users:
...     print(user.id)
...
1
2
3
4
```

For beginners, this will be a valuable tool for them to be able to play around with the container in an interactive way.

If there's anything else you want me to import by default into this console, that can easily be done.