### PR TITLE
Add routes command

### DIFF
--- a/masonite/commands/RoutesCommand.py
+++ b/masonite/commands/RoutesCommand.py
@@ -1,0 +1,35 @@
+\
+from cleo import Command
+from tabulate import tabulate
+
+
+class RoutesCommand(Command):
+    """
+    List out all routes of the application.
+
+    routes
+    """
+
+    def handle(self):
+        from wsgi import container
+
+        web_routes = container.make('WebRoutes')
+
+        routes = [[
+            "Method",
+            "Path",
+            "Name",
+            "Domain",
+            "Middleware"
+        ]]
+
+        for route in web_routes:
+            routes.append([
+                route.method_type,
+                route.route_url,
+                route.named_route,
+                route.required_domain,
+                ','.join(route.list_middleware),
+            ])
+
+        print(tabulate(routes, headers="firstrow", tablefmt="rst"))

--- a/masonite/commands/RoutesCommand.py
+++ b/masonite/commands/RoutesCommand.py
@@ -1,4 +1,4 @@
-\
+
 from cleo import Command
 from tabulate import tabulate
 
@@ -7,7 +7,7 @@ class RoutesCommand(Command):
     """
     List out all routes of the application.
 
-    routes
+    show:routes
     """
 
     def handle(self):

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -12,6 +12,7 @@ from masonite.commands.MigrateResetCommand import MigrateResetCommand
 from masonite.commands.MigrateRollbackCommand import MigrateRollbackCommand
 from masonite.commands.ModelCommand import ModelCommand
 from masonite.commands.ProviderCommand import ProviderCommand
+from masonite.commands.RoutesCommand import RoutesCommand
 from masonite.commands.ServeCommand import ServeCommand
 from masonite.commands.TinkerCommand import TinkerCommand
 from masonite.commands.ViewCommand import ViewCommand
@@ -52,6 +53,7 @@ class AppProvider(ServiceProvider):
         self.app.bind('MasoniteModelCommand', ModelCommand())
         self.app.bind('MasoniteProviderCommand', ProviderCommand())
         self.app.bind('MasoniteViewCommand', ViewCommand())
+        self.app.bind('MasoniteRoutesCommand', RoutesCommand())
         self.app.bind('MasoniteServeCommand', ServeCommand())
         self.app.bind('MasoniteTinkerCommand', TinkerCommand())
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'masonite-entry>=0.0.0,<=0.9.99',
         'pendulum==1.4.4',
         'cleo==0.6.5',
+        'tabulate==0.8.2',
     ],
     description='The core for the Masonite framework',
     author='Joseph Mancuso',


### PR DESCRIPTION
Another command for the new release.

The routes command is simply a convenience craft command which shows you the registered routes in the application.

The routes command will show a table like the following:

```
========  ====================  ===================  ========  ============
Method    Path                  Name                 Domain    Middleware
========  ====================  ===================  ========  ============
GET       /                     welcome                        auth
GET       /login
GET       /logout
POST      /login
GET       /register
POST      /register
========  ====================  ===================  ========  ============
```

This will be especially useful as we add more places to define routes (web.py + api.py, global routes, etc.).