### PR TITLE
Add optional code reloading into the masonite serve command

### DIFF
--- a/masonite/commands/ServeCommand.py
+++ b/masonite/commands/ServeCommand.py
@@ -16,7 +16,7 @@ class ServeCommand(Command):
     serve
         {--port=8000 : Specify which port to run the server}
         {--host=127.0.0.1 : Specify which ip address to run the server}
-        {--reload : Make the server automatically reload on file changes}
+        {--r|reload : Make the server automatically reload on file changes}
     """
 
     def handle(self):

--- a/masonite/commands/ServeCommand.py
+++ b/masonite/commands/ServeCommand.py
@@ -1,4 +1,11 @@
-from subprocess import call
+
+import os
+import sys
+import time
+import subprocess
+import threading
+
+import waitress
 from cleo import Command
 
 
@@ -9,14 +16,276 @@ class ServeCommand(Command):
     serve
         {--port=8000 : Specify which port to run the server}
         {--host=127.0.0.1 : Specify which ip address to run the server}
+        {--reload : Make the server automatically reload on file changes}
     """
 
     def handle(self):
+        # try:
+        #     call([
+        #         "waitress-serve", '--port', self.option('port'),
+        #         "--host", self.option('host'), "wsgi:application"
+        #     ])
+        # except Exception:
+        #     self.line('')
+        #     self.comment('Server aborted!')
+        if self.option('reload'):
+            self._run_with_reloader(extra_files=[".env"])
+
+        else:
+            self._run_application()
+
+    def _run_application(self):
+        from wsgi import application
+        waitress.serve(
+            application,
+            host=self.option('host'),
+            port=self.option('port'))
+
+    def _run_with_reloader(self, extra_files=None, interval=1):
+        """Run the given function in an independent python interpreter."""
+        import signal
+        from wsgi import application
+        reloader = WatchdogReloaderLoop(extra_files, interval, log_func=self.comment)
+        signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
         try:
-            call([
-                "waitress-serve", '--port', self.option('port'),
-                "--host", self.option('host'), "wsgi:application"
-            ])
-        except Exception:
-            self.line('')
-            self.comment('Server aborted!')
+            if os.environ.get('MASONITE_RUN_MAIN') == 'true':
+                t = threading.Thread(target=self._run_application, args=())
+                t.setDaemon(True)
+                t.start()
+                reloader.run()
+            else:
+                sys.exit(reloader.restart_with_reloader())
+        except KeyboardInterrupt:
+            pass
+
+'''
+|--------------------------------------------------------------------------
+| Automatic Reloading Code
+|--------------------------------------------------------------------------
+|
+| The grand majority of this auto-reloading code is based on the automatic
+| reloading code provided by Werkzeug. I edited it to remove support for
+| Python 2x and to use only Watchdog, since we will know that watchdog
+| is present. Additionally, I changed the light logging it had to hook
+| into Cleo's logging system.
+|
+| Werkzeug is licensed under a BSD-like open source license. The original
+| work can be found at the link below.
+|
+| https://github.com/pallets/werkzeug
+|
+'''
+
+iteritems = lambda d, *args, **kwargs: iter(d.items(*args, **kwargs))
+
+
+def _iter_module_files():
+    """This iterates over all relevant Python files.  It goes through all
+    loaded files from modules, all files in folders of already loaded modules
+    as well as all files reachable through a package.
+    """
+    # The list call is necessary on Python 3 in case the module
+    # dictionary modifies during iteration.
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        filename = getattr(module, '__file__', None)
+        if filename:
+            if os.path.isdir(filename) and \
+               os.path.exists(os.path.join(filename, "__init__.py")):
+                filename = os.path.join(filename, "__init__.py")
+
+            old = None
+            while not os.path.isfile(filename):
+                old = filename
+                filename = os.path.dirname(filename)
+                if filename == old:
+                    break
+            else:
+                if filename[-4:] in ('.pyc', '.pyo'):
+                    filename = filename[:-1]
+                yield filename
+
+
+def _find_observable_paths(extra_files=None):
+    """Finds all paths that should be observed."""
+    rv = set(os.path.dirname(os.path.abspath(x))
+             if os.path.isfile(x) else os.path.abspath(x)
+             for x in sys.path)
+
+    for filename in extra_files or ():
+        rv.add(os.path.dirname(os.path.abspath(filename)))
+
+    for module in list(sys.modules.values()):
+        fn = getattr(module, '__file__', None)
+        if fn is None:
+            continue
+        fn = os.path.abspath(fn)
+        rv.add(os.path.dirname(fn))
+
+    return _find_common_roots(rv)
+
+
+def _get_args_for_reloading():
+    """Returns the executable. This contains a workaround for windows
+    if the executable is incorrectly reported to not have the .exe
+    extension which can cause bugs on reloading.
+    """
+    rv = [sys.executable]
+    py_script = sys.argv[0]
+    if os.name == 'nt' and not os.path.exists(py_script) and \
+       os.path.exists(py_script + '.exe'):
+        py_script += '.exe'
+    if os.path.splitext(rv[0])[1] == '.exe' and os.path.splitext(py_script)[1] == '.exe':
+        rv.pop(0)
+    rv.append(py_script)
+    rv.extend(sys.argv[1:])
+    return rv
+
+
+def _find_common_roots(paths):
+    """Out of some paths it finds the common roots that need monitoring."""
+    paths = [x.split(os.path.sep) for x in paths]
+    root = {}
+    for chunks in sorted(paths, key=len, reverse=True):
+        node = root
+        for chunk in chunks:
+            node = node.setdefault(chunk, {})
+        node.clear()
+
+    rv = set()
+
+    def _walk(node, path):
+        for prefix, child in iteritems(node):
+            _walk(child, path + (prefix,))
+        if not node:
+            rv.add('/'.join(path))
+    _walk(root, ())
+    return rv
+
+
+class ReloaderLoop(object):
+    name = None
+
+    # monkeypatched by testsuite. wrapping with `staticmethod` is required in
+    # case time.sleep has been replaced by a non-c function (e.g. by
+    # `eventlet.monkey_patch`) before we get here
+    _sleep = staticmethod(time.sleep)
+
+    def __init__(self, extra_files=None, interval=1, log_func=None):
+        self.extra_files = set(os.path.abspath(x)
+                               for x in extra_files or ())
+        self.interval = interval
+        self.log_func = log_func
+
+    def _log(self, message):
+        if self.log_func:
+            self.log_func(' [*] {}'.format(message))
+
+    def run(self):
+        pass
+
+    def restart_with_reloader(self):
+        """Spawn a new Python interpreter with the same arguments as this one,
+        but running the reloader thread.
+        """
+        while 1:
+            self._log('Restarting with %s' % self.name)
+            args = _get_args_for_reloading()
+            new_environ = os.environ.copy()
+            new_environ['MASONITE_RUN_MAIN'] = 'true'
+
+            exit_code = subprocess.call(args, env=new_environ,
+                                        close_fds=False)
+            if exit_code != 3:
+                return exit_code
+
+    def trigger_reload(self, filename):
+        self.log_reload(filename)
+        sys.exit(3)
+
+    def log_reload(self, filename):
+        filename = os.path.abspath(filename)
+        self._log('Detected change in %r, reloading' % filename)
+
+
+class WatchdogReloaderLoop(ReloaderLoop):
+
+    def __init__(self, *args, **kwargs):
+        ReloaderLoop.__init__(self, *args, **kwargs)
+        from watchdog.observers import Observer
+        from watchdog.events import FileSystemEventHandler
+        self.observable_paths = set()
+
+        def _check_modification(filename):
+            if filename in self.extra_files:
+                self.trigger_reload(filename)
+            dirname = os.path.dirname(filename)
+            if dirname.startswith(tuple(self.observable_paths)):
+                if filename.endswith(('.pyc', '.pyo', '.py')):
+                    self.trigger_reload(filename)
+
+        class _CustomHandler(FileSystemEventHandler):
+
+            def on_created(self, event):
+                _check_modification(event.src_path)
+
+            def on_modified(self, event):
+                _check_modification(event.src_path)
+
+            def on_moved(self, event):
+                _check_modification(event.src_path)
+                _check_modification(event.dest_path)
+
+            def on_deleted(self, event):
+                _check_modification(event.src_path)
+
+        reloader_name = Observer.__name__.lower()
+        if reloader_name.endswith('observer'):
+            reloader_name = reloader_name[:-8]
+        reloader_name += ' reloader'
+
+        self.name = reloader_name
+
+        self.observer_class = Observer
+        self.event_handler = _CustomHandler()
+        self.should_reload = False
+
+    def trigger_reload(self, filename):
+        # This is called inside an event handler, which means throwing
+        # SystemExit has no effect.
+        # https://github.com/gorakhargosh/watchdog/issues/294
+        self.should_reload = True
+        self.log_reload(filename)
+
+    def run(self):
+        watches = {}
+        observer = self.observer_class()
+        observer.start()
+
+        try:
+            while not self.should_reload:
+                to_delete = set(watches)
+                paths = _find_observable_paths(self.extra_files)
+                for path in paths:
+                    if path not in watches:
+                        try:
+                            watches[path] = observer.schedule(
+                                self.event_handler, path, recursive=True)
+                        except OSError:
+                            # Clear this path from list of watches We don't want
+                            # the same error message showing again in the next
+                            # iteration.
+                            watches[path] = None
+                    to_delete.discard(path)
+                for path in to_delete:
+                    watch = watches.pop(path, None)
+                    if watch is not None:
+                        observer.unschedule(watch)
+                self.observable_paths = paths
+                self._sleep(self.interval)
+        finally:
+            observer.stop()
+            observer.join()
+
+        sys.exit(3)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'pendulum==1.4.4',
         'cleo==0.6.5',
         'tabulate==0.8.2',
+        'watchdog==0.8.3',
     ],
     description='The core for the Masonite framework',
     author='Joseph Mancuso',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'cleo==0.6.5',
         'tabulate==0.8.2',
         'watchdog==0.8.3',
+        'waitress==1.1.0',
     ],
     description='The core for the Masonite framework',
     author='Joseph Mancuso',


### PR DESCRIPTION
Yet another command change here for the develop branch. After searching for waitress code reloading, I realized it didn't have any.

I've updated the `craft serve` command to have automatic code reloading. This makes it easier to develop applications in masonite as we won't have to restart the development server in between edits to the code base. You enable code reloading by running `craft serve --reload`. By default, code reloading is turned off.  

The command still uses the waitress server, however, it imports the server rather than calling it out to a subprocess. Using watchdog, it efficiently watches for python files and the `.env` file to change and restarts the server. Updates to HTML and static assets are already reloaded (by design of the Jinja2 and Whitenoise).

There is one downside to automatic code reloading, which is the main reason why I've put this as labelled this as requires discussion. The downside is that the `memory` session driver (default) will break every time the code reloads as the server completely restarts. The obvious work around is to set the session driver to `cookie`.

1. Is this downside something that we can live with?
2. Should we set the session driver to `cookie` by default in 2.0?