### PR TITLE
fixed container resolution resolving similiar objects

### DIFF
--- a/masonite/app.py
+++ b/masonite/app.py
@@ -102,8 +102,19 @@ class App():
         """
         Find a given annotation in the container
         """
+        found = False
+        return_class = None
         for provider, provider_class in self.providers.items():
-            if parameter.annotation == provider_class.__class__ or parameter.annotation == provider_class or isinstance(provider_class, parameter.annotation.__class__):
+            
+            if parameter.annotation == provider_class or parameter.annotation == provider_class.__class__:
                 return provider_class
+            elif hasattr(provider_class, '__name__') and parameter.annotation == provider_class.__name__:
+                return provider_class
+            elif inspect.isclass(provider_class) and issubclass(provider_class, parameter.annotation):
+                found = True
+                return_class = provider_class
+        
+        if found is True:
+            return return_class
         
         raise ContainerError('The dependency with the {0} annotation could not be resolved by the container'.format(parameter))

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -6,13 +6,18 @@ from masonite.exceptions import ContainerError
 import pytest
 
 
-
-
 class MockObject:
     pass
 
 class GetObject(MockObject):
-    pass
+    
+    def find(self):
+        return 1
+
+class GetAnotherObject(MockObject):
+
+    def find(self):
+        return 2
 
 class TestContainer:
 
@@ -40,6 +45,20 @@ class TestContainer:
     def test_container_resolving_instance_of_object(self):
         # assert isinstance(GetObject, MockObject.__class__)
         assert isinstance(self.app.resolve(self._function_test_annotation), GetObject.__class__)
+    
+    def test_container_resolving_similiar_objects(self):
+        self.app.bind('GetAnotherObject', GetAnotherObject)
+
+        obj = self.app.resolve(self._function_test_find_method_on_similiar_objects)
+        assert obj[0] == 2
+        assert obj[1] == 1
+    
+    def _function_test_find_method_on_similiar_objects(self, user: GetAnotherObject, country: GetObject):
+        return [user().find(), country().find()]
+
+    def test_raises_error_when_getting_instances_of_classes(self):
+        with pytest.raises(ContainerError):
+            assert self.app.resolve(self._function_test_find_method_on_similiar_objects)
 
     def _function_test_double_annotations(self, mock: MockObject, request: Request):
         return {'mock': MockObject, 'request': Request}


### PR DESCRIPTION
fixed container resolution.

A bug I found when resolving multiple models loaded into the container is that they were all returning the same model. What the container was doing was searching through the `Country` and `User` model but when annotating them:

```python
from app.User import User
from app.Country import Country

def show(self, user: User, country: Country):
    pass
```

both `user` and `country` were returning the user model. I think this was because `ininstance(user, country)` is true. so it was finding the first instance.

Now what happens is that it will loop through the container and if it finds an instance, it will save it and continue the loop. If nothing else is returned then it will return the instance it found. I'm not entirely sure this is the expected behavior of the container and it can take a longer time to fetch things from the container when resolving instances but it's the best solution I found so far.

Because this is sort of a bug fix, this can go into 1.6.