### PR TITLE
added collection of subclasses to container

### DIFF
--- a/masonite/app.py
+++ b/masonite/app.py
@@ -65,24 +65,30 @@ class App():
         return obj(*provider_list)
 
     def collect(self, search):
-        # Search Can Be:
-        #    '*ExceptionHook'
-        #    'Sentry*'
-        #    'Sentry*Hook'
         provider_list = {}
-        for key, value in self.providers.items():
-            if search.startswith('*'):
-                if key.endswith(search.split('*')[1]):
-                    provider_list.update({key: value})
-            elif search.endswith('*'):
-                if key.startswith(search.split('*')[0]):
-                    provider_list.update({key: value})
-            elif '*' in search:
-                split_search = search.split('*')
-                if key.startswith(split_search[0]) and key.endswith(split_search[1]):
-                    provider_list.update({key: value})
-            else:
-                raise AttributeError("There is no '*' in your collection search")
+        if isinstance(search, str):
+            # Search Can Be:
+            #    '*ExceptionHook'
+            #    'Sentry*'
+            #    'Sentry*Hook'
+            for key, value in self.providers.items():
+                if search.startswith('*'):
+                    if key.endswith(search.split('*')[1]):
+                        provider_list.update({key: value})
+                elif search.endswith('*'):
+                    if key.startswith(search.split('*')[0]):
+                        provider_list.update({key: value})
+                elif '*' in search:
+                    split_search = search.split('*')
+                    if key.startswith(split_search[0]) and key.endswith(split_search[1]):
+                        provider_list.update({key: value})
+                else:
+                    raise AttributeError("There is no '*' in your collection search")
+        else:
+            for provider_key, provider_class in self.providers.items():
+                if inspect.isclass(provider_class) and issubclass(provider_class, search):
+                    provider_list.update({provider_key: provider_class})
+                    
         return provider_list
 
     def _find_parameter(self, parameter):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'masonite.contracts',
         'masonite.helpers',
     ],
-    version='1.6.9',
+    version='1.6.10',
     install_requires=[
         'validator.py==1.2.5',
         'cryptography==2.2.2',

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -97,15 +97,10 @@ class TestContainer:
         assert self.app.collect('Sentry*Hook') == {'SentryExceptionHook': object}
         with pytest.raises(AttributeError):
             self.app.collect('Sentry')
-
-
-
-
-
-
-
-
-
-
-
-
+    
+    def test_container_collects_correct_subclasses_of_objects(self):
+        self.app.bind('GetAnotherObject', GetAnotherObject)
+        objects = self.app.collect(MockObject)
+        
+        assert 'GetAnotherObject' in objects
+        assert 'GetObject' in objects


### PR DESCRIPTION
we can now collect objects from the container based on a class. So we may use this for getting all classes in the container that are children classes of an object.

For example:

```python
from masonite.drivers.BaseDriver import BaseDriver

app.collect(BaseDriver)
```

will fetch every driver in the container because they all extend from this base driver.

closes #148 