### PR TITLE
fixed request redirect method name

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -295,7 +295,7 @@ class Request(Extendable):
         self.redirect_url = self.compile_route_to_url(route, params)
         return self
 
-    def redirectTo(self, route_name, params={}):
+    def redirect_to(self, route_name, params={}):
         """
         Redirect to a named route
         """

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -160,7 +160,7 @@ class TestRequest:
 
         assert request.redirect_url is False
 
-        request.redirectTo('test')
+        request.redirect_to('test')
 
         assert request.redirect_url == '/test'
 


### PR DESCRIPTION
There was a naming convention error of:

```python
request().redirectTo()
```

where the naming scheme should have been:

```python
request().redirect_to()
```