### PR TITLE
added autoloading instances from a directory

### DIFF
--- a/masonite/autoload.py
+++ b/masonite/autoload.py
@@ -6,7 +6,9 @@ from masonite.exceptions import InvalidAutoloadPath
 
 class Autoload:
 
-    def __init__(self, app):
+    classes = {}
+
+    def __init__(self, app=None):
         self.app = app
 
     def load(self, directories):     
@@ -19,3 +21,16 @@ class Autoload:
             for obj in inspect.getmembers(mod):
                 if inspect.isclass(obj[1]):
                     self.app.bind(obj[1].__name__, obj[1])
+    
+    def instances(self, directories, instance):
+        for (module_loader, name, ispkg) in pkgutil.iter_modules(directories):
+            search_path = module_loader.path
+            if search_path.endswith('/'):
+                raise InvalidAutoloadPath('Autoload path cannot have a trailing slash')
+                
+            mod = importlib.import_module(module_loader.path.replace('/', '.') + '.' + name)
+            for obj in inspect.getmembers(mod):
+                if inspect.isclass(obj[1]) and issubclass(obj[1], instance):
+                    self.classes.update({obj[1].__name__: obj[1]})
+
+        return self

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -17,3 +17,7 @@ class TestAutoload:
         with pytest.raises(InvalidAutoloadPath):
             Autoload(self.app).load(['app/http/controllers/'])
     
+    
+    def test_autoload_loads_from_directories_and_instances(self):
+        classes = Autoload().instances(['app/http/controllers'], object).classes
+        assert 'TestController' in classes


### PR DESCRIPTION
added autoloading of instances.

This looks like:

```python
from scheduler.task import Task

classes = Autoload().instances(Task) # dictionary of classes from that directory
```

- [x] Documentation