### PR TITLE
Change internal request variables

### DIFF
--- a/masonite/helpers/view_helpers.py
+++ b/masonite/helpers/view_helpers.py
@@ -1,2 +1,2 @@
 def set_request_method(method_type):
-    return "<input type='hidden' name='request_method' value='{0}'>".format(method_type)
+    return "<input type='hidden' name='__method' value='{0}'>".format(method_type)

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -61,8 +61,8 @@ class Request(Extendable):
         return False
 
     def __set_request_method(self):
-        if self.has('request_method'):
-            self.environ['REQUEST_METHOD'] = self.input('request_method')
+        if self.has('__method'):
+            self.environ['REQUEST_METHOD'] = self.input('__method')
             return True
 
         return False
@@ -105,7 +105,7 @@ class Request(Extendable):
 
         self._set_standardized_request_variables(environ['QUERY_STRING'])
 
-        if self.has('request_method'):
+        if self.has('__method'):
             self.__set_request_method()
 
         return self
@@ -149,6 +149,9 @@ class Request(Extendable):
 
     def get_status_code(self):
         return self._status
+    
+    def get_request_method(self):
+        return self.environ['REQUEST_METHOD']
 
     def header(self, key, value=None, http_prefix=True):
         # Get Headers

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -75,11 +75,17 @@ class Request(Extendable):
         self.encryption_key = key
         return self
 
-    def all(self):
+    def all(self, internal_variables=True):
         """
         Returns all the request variables
         """
-
+        if not internal_variables:
+            without_internals = {}
+            for key, value in self.request_variables.items():
+                if not key.startswith('__'):
+                    without_internals.update({key: value})
+            return without_internals
+        
         return self.request_variables
 
     def only(self, *names):

--- a/middleware/CsrfMiddleware.py
+++ b/middleware/CsrfMiddleware.py
@@ -1,10 +1,9 @@
+''' CSRF Middleware '''
 from masonite.exceptions import InvalidCSRFToken
 
 
-class CsrfMiddleware(object):
-    """
-    Verify csrf token middleware
-    """
+class CsrfMiddleware:
+    ''' Verify CSRF Token Middleware '''
 
     exempt = ['/']
 
@@ -14,11 +13,10 @@ class CsrfMiddleware(object):
         self.view = ViewClass
 
     def before(self):
-        # Verify token
         token = self.__verify_csrf_token()
 
         self.view.share({
-            'csrf_field': "<input type='hidden' name='csrf_token' value='{0}' />".format(token)
+            'csrf_field': "<input type='hidden' name='__token' value='{0}' />".format(token)
         })
 
     def after(self):
@@ -41,7 +39,7 @@ class CsrfMiddleware(object):
         """
 
         if self.request.is_post() and not self.__in_exempt():
-            token = self.request.input('csrf_token')
+            token = self.request.input('__token')
             if not self.csrf.verify_csrf_token(token):
                 raise InvalidCSRFToken("Invalid CSRF token.")
         else:

--- a/tests/middleware/test_csrf_middleware.py
+++ b/tests/middleware/test_csrf_middleware.py
@@ -1,0 +1,37 @@
+from masonite.request import Request
+from masonite.view import View
+from masonite.auth.Csrf import Csrf
+from masonite.app import App
+from middleware.CsrfMiddleware import CsrfMiddleware
+from masonite.testsuite.TestSuite import generate_wsgi
+import pytest
+from masonite.exceptions import InvalidCSRFToken
+
+class TestCSRFMiddleware:
+
+    def setup_method(self):
+        self.app = App()
+        self.request = Request(generate_wsgi())    
+        self.view = View(self.app)
+        self.app.bind('Request', self.request)
+
+        self.request = self.app.make('Request')
+
+        self.middleware = CsrfMiddleware(self.request, Csrf(self.request), self.view)
+    
+    def test_middleware_shares_correct_input(self):
+        self.middleware.before()
+        assert 'csrf_field' in self.view.dictionary
+        assert self.view.dictionary['csrf_field'].startswith("<input type='hidden' name='__token' value='")
+
+    def test_middleware_throws_exception_on_post(self):
+        self.request.environ['REQUEST_METHOD'] = 'POST'
+        self.middleware.exempt = []
+        with pytest.raises(InvalidCSRFToken):
+            self.middleware.before()
+
+    def test_incoming_token_does_not_throw_exception_with_token(self):
+        self.request.environ['REQUEST_METHOD'] = 'POST'
+        self.request.request_variables.update({'__token': self.request.get_cookie('csrf_token')})
+        self.middleware.exempt = []
+        self.middleware.before()

--- a/tests/test_extends.py
+++ b/tests/test_extends.py
@@ -90,7 +90,7 @@ class TestExtends:
 
     def test_hidden_form_request_method_changes_request_method(self):
         app = App()
-        wsgi_request['QUERY_STRING'] = 'request_method=PUT'
+        wsgi_request['QUERY_STRING'] = '__method=PUT'
         request_class = Request(wsgi_request)
 
         app.bind('Request', request_class)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -298,3 +298,12 @@ class TestRequest:
 
         request.status('200 OK')
         assert request.get_status_code() == '200 OK'
+
+    def test_request_sets_request_method(self):
+        wsgi = generate_wsgi()
+        wsgi['QUERY_STRING'] = '__method=PUT'
+        request = Request(wsgi)
+
+        assert request.has('__method')
+        assert request.input('__method') == 'PUT'
+        assert request.get_request_method() == 'PUT'

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -34,6 +34,11 @@ class TestRequest:
 
     def test_request_all_should_return_params(self):
         assert self.request.all() == {'application': 'Masonite'}
+    
+    def test_request_all_without_internal_request_variables(self):
+        self.request.request_variables.update({'__token': 'testing', 'application': 'Masonite'})
+        assert self.request.all() == {'__token': 'testing', 'application': 'Masonite'}
+        assert self.request.all(internal_variables=False) == {'application': 'Masonite'}
 
 
     def test_request_has_should_return_bool(self):
@@ -307,3 +312,4 @@ class TestRequest:
         assert request.has('__method')
         assert request.input('__method') == 'PUT'
         assert request.get_request_method() == 'PUT'
+    


### PR DESCRIPTION
Closes #120 

* Adds a new `get_request_method` method to request class
* adds a new parameter to the `all()` method to get all the inputs without the framework internals
* changed the csrf middleware accordingly.
* added tests for csrf middleware