### PR TITLE
Fix subdomains

### DIFF
--- a/masonite/providers/RouteProvider.py
+++ b/masonite/providers/RouteProvider.py
@@ -69,7 +69,7 @@ class RouteProvider(ServiceProvider):
                     # check if the subdomain matches the routes domain
                     if not route.has_required_domain():
                         self.app.bind('Response', 'Route not found. Error 404')
-                        break
+                        continue
                 """
                 |--------------------------------------------------------------------------
                 | Execute Before Middleware

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -32,6 +32,7 @@ class Request(Extendable):
         self.redirect_route = False
         self.user_model = None
         self.subdomain = None
+        self._activate_subdomains = False
         self._status = '404 Not Found'
 
         if environ:
@@ -362,14 +363,18 @@ class Request(Extendable):
             compiled_url = compiled_url.replace('//', '/')
 
         return compiled_url
+    
+    def activate_subdomains(self):
+        self._activate_subdomains = True
 
     def has_subdomain(self):
-        url = tldextract.extract(self.environ['HTTP_HOST'])
+        if self._activate_subdomains:
+            url = tldextract.extract(self.environ['HTTP_HOST'])
 
-        if url.subdomain:
-            self.subdomain = url.subdomain
-            self.url_params.update({'subdomain': self.subdomain})
-            return True
+            if url.subdomain:
+                self.subdomain = url.subdomain
+                self.url_params.update({'subdomain': self.subdomain})
+                return True
 
         return False
 

--- a/tests/providers/test_route_provider.py
+++ b/tests/providers/test_route_provider.py
@@ -86,10 +86,13 @@ class TestRouteProvider:
         self.app.make('Environ')['HTTP_HOST'] = 'subb.domain.com'
         self.app.bind('WebRoutes', [get('/test', Controller.show)])
 
+        request = self.app.make('Request')
+        request.activate_subdomains()
+
         self.provider.boot(
             self.app.make('WebRoutes'),
             self.app.make('Route'),
-            self.app.make('Request'),
+            request,
             self.app.make('Environ'),
             self.app.make('Headers'),
         )

--- a/tests/test_request_routes.py
+++ b/tests/test_request_routes.py
@@ -8,6 +8,8 @@ class TestRequestRoutes:
     def setup_method(self):
         self.request = Request(generate_wsgi()).key(
             'NCTpkICMlTXie5te9nJniMj9aVbPM6lsjeq5iDZ0dqY=')
+        
+        self.request.activate_subdomains()
 
     def test_get_initialized(self):
         assert callable(Get)
@@ -67,6 +69,8 @@ class TestRequestRoutes:
 
         request.environ['HTTP_HOST'] = 'test.localhost:8000'
 
+        request.activate_subdomains()
+
         get = Get().domain('*')
         post = Get().domain('*')
 
@@ -82,6 +86,8 @@ class TestRequestRoutes:
         request = container.container.make('Request')
 
         request.environ['HTTP_HOST'] = 'test.localhost:8000'
+
+        request.activate_subdomains()
 
         get = Get().domain('*')
         post = Get().domain('*')


### PR DESCRIPTION
This PR fixes a bug found in testing. The issue is that some deployment services like Heroku deploy with a subdomain prefix to the URL. By default, Masonite has subdomains turned on so none of the routes will show without explicitly declaring them as having a domain like:

```python
get('/url/here', 'Controller@method').domain('chilly-cabin-8726')
```

in order to get it to work with Masonite. This is slightly annoying and the expected behavior of a framework is to have subdomains turned off. So now if you would like subdomains to work you will need to create a service provider and activate subdomains like so:

```python
...
wsgi = False

def boot(self, Request):
    Request.activate_subdomains()
```

This will set a new attribute on the request class whether the has_subdomain() method returns true or False

This PR also fixes a bug which was that subdomains could not have the same URL as non subdomain routes. If a subdomain was checked it would `break` out of the loop when the expected behavior is for it to be `continue`