### PR TITLE
add improvements to autoloader

### DIFF
--- a/app/http/controllers/TestController.py
+++ b/app/http/controllers/TestController.py
@@ -1,4 +1,9 @@
+from cleo import Command
+
 class TestController:
+
+    def __init__(self):
+        self.test = True
 
     def show():
         pass

--- a/masonite/autoload.py
+++ b/masonite/autoload.py
@@ -1,7 +1,7 @@
 from pydoc import importlib
 import pkgutil
 import inspect
-from masonite.exceptions import InvalidAutoloadPath, AutoloadContainerOverwrite
+from masonite.exceptions import InvalidAutoloadPath, AutoloadContainerOverwrite, ContainerError
 
 
 class Autoload:
@@ -11,31 +11,62 @@ class Autoload:
     def __init__(self, app=None):
         self.app = app
 
-    def load(self, directories):     
+    def load(self, directories, instantiate=False):
+        self.instantiate = instantiate
+        if not self.app:
+            raise ContainerError('Container not specified. Pass the container into the constructor')
+
         for (module_loader, name, ispkg) in pkgutil.iter_modules(directories):
             search_path = module_loader.path
-            if search_path.endswith('/'):
-                raise InvalidAutoloadPath('Autoload path cannot have a trailing slash')
-                
-            mod = importlib.import_module(module_loader.path.replace('/', '.') + '.' + name)
-            for obj in inspect.getmembers(mod):
+            for obj in inspect.getmembers(self._get_module_members(module_loader, name)):
 
                 # If the object is a class and the objects module starts with the search path
                 if inspect.isclass(obj[1]) and obj[1].__module__.startswith(search_path.replace('/', '.')):
                     if self.app.has(obj[1].__name__) and not self.app.make(obj[1].__name__).__module__.startswith(search_path):
                         raise AutoloadContainerOverwrite(
                             'Container already has the key: {}. Cannot overwrite a container key that exists outside of your application.'.format(obj[1].__name__))
-                    self.app.bind(obj[1].__name__, obj[1])
+                    self.app.bind(obj[1].__name__, self._can_instantiate(obj))
     
-    def instances(self, directories, instance):
+    def instances(self, directories, instance, only_app=True, instantiate=False):
+        self.instantiate = instantiate
+
         for (module_loader, name, ispkg) in pkgutil.iter_modules(directories):
             search_path = module_loader.path
-            if search_path.endswith('/'):
-                raise InvalidAutoloadPath('Autoload path cannot have a trailing slash')
-                
-            mod = importlib.import_module(module_loader.path.replace('/', '.') + '.' + name)
-            for obj in inspect.getmembers(mod):
+            for obj in inspect.getmembers(self._get_module_members(module_loader, name)):
                 if inspect.isclass(obj[1]) and issubclass(obj[1], instance):
-                    self.classes.update({obj[1].__name__: obj[1]})
+                    if only_app and obj[1].__module__.startswith(search_path.replace('/', '.')):
+                        self.classes.update({obj[1].__name__: self._can_instantiate(obj)})
+                    elif not only_app:
+                        self.classes.update({obj[1].__name__: self._can_instantiate(obj)})
 
         return self
+    
+    def collect(self, directories, only_app=True, instantiate=False):
+        self.instantiate = instantiate
+
+        for (module_loader, name, ispkg) in pkgutil.iter_modules(directories):
+            search_path = module_loader.path
+            
+            for obj in inspect.getmembers(self._get_module_members(module_loader, name)):
+                if inspect.isclass(obj[1]):
+                    if only_app and obj[1].__module__.startswith(search_path.replace('/', '.')): 
+                        self.classes.update({obj[1].__name__: self._can_instantiate(obj)})
+                    elif not only_app:
+                        self.classes.update({obj[1].__name__: self._can_instantiate(obj)})
+
+        return self.classes
+
+    def _can_instantiate(self, obj):
+        if self.instantiate:
+            return obj[1]()
+        
+        return obj[1]
+
+    def _get_module_members(self, module_loader, name):
+        search_path = module_loader.path
+        if search_path.endswith('/'):
+            raise InvalidAutoloadPath(
+                'Autoload path cannot have a trailing slash')
+
+        return importlib.import_module(
+            module_loader.path.replace('/', '.') + '.' + name)

--- a/masonite/autoload.py
+++ b/masonite/autoload.py
@@ -39,7 +39,7 @@ class Autoload:
                     elif not only_app:
                         self.classes.update({obj[1].__name__: self._can_instantiate(obj)})
 
-        return self
+        return self.classes
     
     def collect(self, directories, only_app=True, instantiate=False):
         self.instantiate = instantiate

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -28,21 +28,21 @@ class TestAutoload:
         assert 'Command' not in classes
 
     def test_autoload_loads_from_directories_and_instances(self):
-        classes = Autoload().instances(['app/http/controllers'], object).classes
+        classes = Autoload().instances(['app/http/controllers'], object)
         assert 'TestController' in classes
         assert 'Command' not in classes
     
     def test_autoload_loads_not_only_from_app_from_directories_and_instances(self):
-        classes = Autoload().instances(['app/http/controllers'], object, only_app=False).classes
+        classes = Autoload().instances(['app/http/controllers'], object, only_app=False)
         assert 'TestController' in classes
         assert 'Command' in classes
     
     def test_autoload_instantiates_classes(self):
-        classes = Autoload().instances(['app/http/controllers'], object, instantiate=True).classes
+        classes = Autoload().instances(['app/http/controllers'], object, instantiate=True)
         assert classes['TestController'].test == True
 
     def test_autoload_does_not_instantiate_classes(self):
-        classes = Autoload().instances(['app/http/controllers'], object).classes
+        classes = Autoload().instances(['app/http/controllers'], object)
         with pytest.raises(AttributeError):
             assert classes['TestController'].test == True
     


### PR DESCRIPTION
This adds a 2 new methods to the autoloader and several new parameters.

We can now specify if we want to autoload only objects within our app and not any outside applications:

```python
Autoload().instances(['app/models'], Model)
```

(this defaults to only classes in our app)

or outside our app too which essentially returns all classes found:

```python
Autoload().instances(['app/models'], Model, only_app=False)
```

as well as using the collect which will gather all classes and not just instances:

```python
Autoload().collect(['app/models'], only_app=False)
```

