### PR TITLE
Add route helper

### DIFF
--- a/masonite/providers/HelpersProvider.py
+++ b/masonite/providers/HelpersProvider.py
@@ -26,6 +26,7 @@ class HelpersProvider(ServiceProvider):
             {
                 'request': Request.helper,
                 'auth': Request.user,
-                'request_method': set_request_method
+                'request_method': set_request_method,
+                'route': Request.route,
             }
         )

--- a/masonite/providers/HelpersProvider.py
+++ b/masonite/providers/HelpersProvider.py
@@ -21,6 +21,7 @@ class HelpersProvider(ServiceProvider):
         builtins.container = self.app.helper
         builtins.env = os.getenv
         builtins.resolve = self.app.resolve
+        builtins.route = Request.route
 
         ViewClass.share(
             {

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -309,11 +309,25 @@ class Request(Extendable):
         """
         web_routes = self.container.make('WebRoutes')
 
-        for route in web_routes:
-            if route.named_route == route_name:
-                self.redirect_url = self.compile_route_to_url(route.route_url, params)
+        self.redirect_url = self._get_named_route(route_name, params)
 
         return self
+    
+    def _get_named_route(self, name, params):
+        web_routes = self.container.make('WebRoutes')
+
+        for route in web_routes:
+            if route.named_route == name:
+                return self.compile_route_to_url(route.route_url, params)
+
+        return None
+    
+    def route(self, name, params = {}):
+        web_routes = self.container.make('WebRoutes')
+
+        return self._get_named_route(name, params)
+
+        return None
 
     def reset_redirections(self):
         self.redirect_url = False

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -224,7 +224,18 @@ class TestRequest:
         route = '/'
 
         assert request.compile_route_to_url(route) == '/'
+    
+    def test_request_route_returns_url(self):
+        app = App()
+        app.bind('Request', self.request)
+        app.bind('WebRoutes', [
+            get('/test/url', None).name('test.url'),
+            get('/test/url/@id', None).name('test.id')
+        ])
+        request = app.make('Request').load_app(app)
 
+        assert request.route('test.url') == '/test/url'
+        assert request.route('test.id', {'id': 1}) == '/test/url/1'
 
     def test_redirect_compiles_url_with_multiple_slashes(self):
         app = App()


### PR DESCRIPTION
Closes #199 

****

If we have a route list like this:

```python
ROUTES = [
    get('/url/to/dashboard' ..).name('dashboard'),
    get('/profile/user/@id:int/edit').name('profile.edit')
]
```

We can now use:

```python
def show(self):
    request().route('profile.edit', {'id': 1})
```

or use the new helper function this comes with:

```python
def show(self):
    route('profile.edit', {'id': 1})
```
