### PR TITLE
added is_named_route method

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -339,6 +339,12 @@ class Request(Extendable):
         """
         self.redirect(self.input(input_parameter))
         return self
+    
+    def is_named_route(self, name, params={}):
+        if self._get_named_route(name, params) == self.path:
+            return True
+        
+        return False
 
     def compile_route_to_url(self, route, params={}):
         """

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -340,3 +340,17 @@ class TestRequest:
         assert request.input('__method') == 'PUT'
         assert request.get_request_method() == 'PUT'
     
+    def test_is_named_route(self):
+        app = App()
+        app.bind('Request', self.request)
+        app.bind('WebRoutes', [
+            get('/test/url', None).name('test.url'),
+            get('/test/url/@id', None).name('test.id')
+        ])
+        request = app.make('Request').load_app(app)
+
+        request.path = '/test/url'
+        assert request.is_named_route('test.url')
+
+        request.path = '/test/url/1'
+        assert request.is_named_route('test.id', {'id': 1})


### PR DESCRIPTION
This adds a `request.is_named_route()` method that can be used like this:

```python
# Request: /dashboard/user/edit/1
# Named: dashboard.edit
# Route url looks like: /dashboard/user/edit/@id

def show(self, request: Request):
    request.is_named_route('dashboard.edit', {'id': 1})
```

This method looks at the current path with the params passed and determines if it is a named route 