### PR TITLE
added helper and request contains

### DIFF
--- a/masonite/helpers/routes.py
+++ b/masonite/helpers/routes.py
@@ -60,3 +60,36 @@ def group(url, route_list):
         route.route_url = url + route.route_url
 
     return route_list
+
+def compile_route_to_regex(route):
+    # Split the route
+    split_given_route = route.split('/')
+
+    # compile the provided url into regex
+    url_list = []
+    regex = '^'
+    for regex_route in split_given_route:
+        if '*' in regex_route or '@' in regex_route:
+            if ':int' in regex_route:
+                regex += r'(\d+)'
+            elif ':string' in regex_route:
+                regex += r'([a-zA-Z]+)'
+            else:
+                # default
+                regex += r'(\w+)'
+            regex += r'\/'
+
+            # append the variable name passed @(variable):int to a list
+            url_list.append(
+                regex_route.replace('@', '').replace(
+                    ':int', '').replace(':string', '')
+            )
+        else:
+            regex += regex_route + r'\/'
+
+    if regex.endswith('/') and not route.endswith('/'):
+        regex = regex[:-2]
+
+    regex += '$'
+
+    return regex

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -7,6 +7,8 @@ Methods may return another object if necessary to expand capabilities
 of this class.
 """
 from urllib.parse import parse_qs
+import re
+from masonite.helpers.routes import compile_route_to_regex
 from http import cookies
 
 import tldextract
@@ -325,6 +327,9 @@ class Request(Extendable):
         """
         self.redirect(self.input(input_parameter))
         return self
+
+    def contains(self, route):
+        return re.match(compile_route_to_regex(route), self.path)
 
     def compile_route_to_url(self, route, params={}):
         """

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -329,3 +329,22 @@ class TestRequest:
         assert request.input('__method') == 'PUT'
         assert request.get_request_method() == 'PUT'
     
+    def test_contains_for_path_detection(self):
+        self.request.path = '/test/path'
+        assert self.request.contains('/test/*')        
+        assert self.request.contains('/test/path')        
+        assert not self.request.contains('/test/wrong')     
+
+    def test_contains_for_path_with_digit(self):
+        self.request.path = '/test/path/1'
+        assert self.request.contains('/test/path/*')    
+        assert self.request.contains('/test/path/*:int')   
+
+    def test_contains_for_path_with_digit_and_wrong_contains(self):
+        self.request.path = '/test/path/joe' 
+        assert not self.request.contains('/test/path/*:int')    
+
+    def test_contains_for_path_with_alpha_and_wrong_contains(self):
+        self.request.path = '/test/path/joe' 
+        assert self.request.contains('/test/path/*:string')    
+


### PR DESCRIPTION
Added a new method to the request: `request.contains()`

This method can be used like:

```python
# Request: /dashboard/user/edit
def show(self, request: Request):
    if request.contains('/dashboard/user/*'):
        pass
```

or you can be more explicit:

```python
# Request: /dashboard/user/edit/1
def show(self, request: Request):
    if request.contains('/dashboard/user/edit/*:int'):
        pass
```

which will match `/dashboard/user/edit/1` but not `/dashboard/user/edit/joe` which is very similar to the matching of the route urls