### PR TITLE
Adds url from controller method to request class

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -322,6 +322,23 @@ class Request(Extendable):
 
         return None
     
+    def _get_route_from_controller(self, controller):
+        web_routes = self.container.make('WebRoutes')
+
+        if not isinstance(controller, str):
+            module_location = controller.__module__
+            controller = controller.__qualname__.split('.')
+        else:
+            module_location = 'app.http.controllers'
+            controller = controller.split('@')
+
+        for route in web_routes:
+            if route.controller.__name__ == controller[0] and route.controller_method == controller[1] and route.module_location == module_location:
+                return route
+
+    def url_from_controller(self, controller, params = {}):
+        return self.compile_route_to_url(self._get_route_from_controller(controller).route_url, params)
+    
     def route(self, name, params = {}):
         web_routes = self.container.make('WebRoutes')
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,5 +1,6 @@
 from config import application, providers
 from pydoc import locate
+from app.http.test_controllers.TestController import TestController
 
 from masonite.request import Request
 from masonite.app import App
@@ -340,3 +341,17 @@ class TestRequest:
         assert request.input('__method') == 'PUT'
         assert request.get_request_method() == 'PUT'
     
+    def test_request_url_from_controller(self):
+        app = App()
+        app.bind('Request', self.request)
+        app.bind('WebRoutes', [
+            get('/test/url', 'TestController@show').name('test.url'),
+            get('/test/url/@id', 'ControllerTest@show').name('test.id'),
+            get('/test/url/controller/@id', TestController.show).name('test.controller'),
+        ])
+
+        request = app.make('Request').load_app(app)
+
+        assert request.url_from_controller('TestController@show') == '/test/url'
+        assert request.url_from_controller('ControllerTest@show', {'id': 1}) == '/test/url/1'
+        assert request.url_from_controller(TestController.show, {'id': 1}) == '/test/url/controller/1'


### PR DESCRIPTION
This adds a new `url_from_controller()` method.

You can use this like this:

You have multiple routes like so:

```python
from package.controller import Controller

ROUTES = [
    get('/url/route', 'TestController@show'),
    get('/url/controller/@id', Controller.show),
]
```

```python
from package.controller import Controller

def show(self, request: Request):
    request.url_from_controller('TestController@show') 
    # returns '/url/route'

    request.url_from_controller(Controller.show, {'id': 1}) 
    # returns '/url/controller/1'
```