### PR TITLE
added better back request method

### DIFF
--- a/masonite/helpers/view_helpers.py
+++ b/masonite/helpers/view_helpers.py
@@ -1,2 +1,6 @@
 def set_request_method(method_type):
     return "<input type='hidden' name='__method' value='{0}'>".format(method_type)
+
+
+def back(location):
+    return "<input type='hidden' name='__back' value='{0}'>".format(location)

--- a/masonite/providers/HelpersProvider.py
+++ b/masonite/providers/HelpersProvider.py
@@ -3,7 +3,7 @@ import builtins
 import os
 
 from masonite.provider import ServiceProvider
-from masonite.helpers.view_helpers import set_request_method
+from masonite.helpers.view_helpers import set_request_method, back
 
 
 class HelpersProvider(ServiceProvider):
@@ -29,5 +29,6 @@ class HelpersProvider(ServiceProvider):
                 'auth': Request.user,
                 'request_method': set_request_method,
                 'route': Request.route,
+                'back': back
             }
         )

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -352,12 +352,14 @@ class Request(Extendable):
         self.redirect_url = False
         self.redirect_route = False
 
-    def back(self, input_parameter='back'):
-        """
-        Go to a named route with the back parameter
-        """
-        self.redirect(self.input(input_parameter))
-        return self
+    def back(self, default=None):
+        redirect_url = self.input('__back')
+        if not redirect_url and default:
+            return self.redirect(default)
+        elif not redirect_url and not default:
+            return self.redirect(self.path)  # Some global default?
+        
+        return self.redirect(redirect_url)
     
     def is_named_route(self, name, params={}):
         if self._get_named_route(name, params) == self.path:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -404,3 +404,14 @@ class TestRequest:
         self.request.path = '/dashboard/user/edit/1' 
         assert self.request.contains('/dashboard/user/*:string/*:int')
         
+    def test_back_returns_correct_url(self):
+        self.request.path = '/dashboard/create'
+        self.request.back()
+        assert self.request.redirect_url == '/dashboard/create'
+
+        self.request.back(default='/home')
+        assert self.request.redirect_url == '/home'
+
+        self.request.request_variables = {'__back': '/login'}
+        self.request.back(default='/home')
+        assert self.request.redirect_url == '/login'


### PR DESCRIPTION
This PR adds a better back method than previous. You can use this like so:

a lot of the time we might have a route like this:

```python
ROUTES = [
    get('/dashboard/create', 'Controller@show'),
    post('/dashboard/create', 'Controller@store')

]
```

meaning we have a GET route that shows the create form and then a POST method on the same route. In this instance we can just do this:

```python
def store(self):
    request().back()
```

Which returns the current URL as the redirection but it will be the GET version of it.

****

We can also specify more explicitly what the redirection will be by using a view helper function:

```html
<form action="{{ route('dashboard.create')" method="POST">
    {{ csrf_field|safe }}
    {{ back('/dashboard/create')|safe }}
</form>
```

or possibly even:

```html
<form action="{{ route('dashboard.create')" method="POST">
    {{ csrf_field|safe }}
    {{ back(request().path)|safe }}
</form>
```

and then the back method will look for this new input:

```python
def store(self):
    request().back() # returns the __back input created from the view helper
```

We can also specify a default just incase one is not passed in:

```python
def store(self):
    request().back(default='/login') # returns the __back input created from the view helper or /login if that didn't exist.
```
