### PR TITLE
added session dictionary serialization

### DIFF
--- a/masonite/drivers/SessionCookieDriver.py
+++ b/masonite/drivers/SessionCookieDriver.py
@@ -1,5 +1,6 @@
 from masonite.contracts.SessionContract import SessionContract
 from masonite.drivers.BaseDriver import BaseDriver
+import json
 
 
 class SessionCookieDriver(SessionContract, BaseDriver):
@@ -22,7 +23,7 @@ class SessionCookieDriver(SessionContract, BaseDriver):
 
         cookie = self.request.get_cookie('s_{0}'.format(key))
         if cookie:
-            return cookie
+            return self._get_serialization_value(cookie)
 
         return None
 
@@ -30,6 +31,8 @@ class SessionCookieDriver(SessionContract, BaseDriver):
         """
         Set a new session in object _session
         """
+        if isinstance(value, dict):
+            value = json.dumps(value)
 
         self.request.cookie('s_{0}'.format(key), value)
 
@@ -78,6 +81,9 @@ class SessionCookieDriver(SessionContract, BaseDriver):
         Add temporary data to the session
         """
 
+        if isinstance(value, dict):
+            value = json.dumps(value)
+
         self.request.cookie('s_{0}'.format(key), value, expires='2 seconds')
 
     def reset(self, flash_only=False):
@@ -94,3 +100,9 @@ class SessionCookieDriver(SessionContract, BaseDriver):
         """
 
         return self
+    
+    def _get_serialization_value(self, value):
+        try:
+            return json.loads(value)
+        except ValueError:
+            return value

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -100,8 +100,14 @@ class TestSession:
         session.reset(flash_only=True)
         assert session.get('flash_') is None
 
+    def test_session_flash_data_serializes_dict(self):
+        for driver in ('cookie', 'memory'):
+            session = self.app.make('SessionManager').driver(driver)
+            session._session = {}
+            session.flash('flash_dict', {'id': 1})
+            assert session.get('flash_dict') == {'id': 1}
 
-    def test_reset_session(self):
+    def test_reset_serializes_dict(self):
         for driver in ('memory', 'cookie'):
             session = self.app.make('SessionManager').driver(driver)
             session.set('flash_', 'test_pep')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -105,7 +105,9 @@ class TestSession:
             session = self.app.make('SessionManager').driver(driver)
             session._session = {}
             session.flash('flash_dict', {'id': 1})
+            session.set('get_dict', {'id': 1})
             assert session.get('flash_dict') == {'id': 1}
+            assert session.get('get_dict') == {'id': 1}
 
     def test_reset_serializes_dict(self):
         for driver in ('memory', 'cookie'):


### PR DESCRIPTION
This PR adds the ability to add a dictionary to the session.

****

I wanted to send errors back to the form doing something like this:

```python
        validate = RegisterValidator(Request).register()

        if not validate.check():
            Request.session.flash('validation', validate.errors())
            return Request.redirect_to('register')
```

and then doing something like this in the template:

```html
        {% if session().has('validation') %}
            <div class="alert alert-danger">
                <ul>
                    {% for key, value in session().get('validation').items() %}
                        <li>{{ value }}</li>
                    {% endfor %}
                </ul>
            </div>
        {% endif %}
```

But this wasn't possible because we were saving the cookie as a string. Now if the cookie is a dictionary then it will serialize and unserialize the cookie as json.

The memory driver already stores it as a dictionary so no need to serialize or unserialize there:

```python
            session.flash('flash_dict', {'id': 1})
            session.set('get_dict', {'id': 1})
            assert session.get('flash_dict') == {'id': 1}
            assert session.get('get_dict') == {'id': 1}
```