### PR TITLE
Make middleware classes

### DIFF
--- a/app/http/middleware/TestHttpMiddleware.py
+++ b/app/http/middleware/TestHttpMiddleware.py
@@ -1,0 +1,10 @@
+class TestHttpMiddleware:
+    ''' Test Middleware '''
+
+    def __init__(self, Request):
+        ''' Inject Any Dependencies From The Service Container '''
+        self.request = Request
+
+    def before(self):
+        ''' Run This Middleware Before The Route Executes '''
+        self.request.environ['HTTP_TEST'] = 'test'

--- a/app/http/middleware/TestMiddleware.py
+++ b/app/http/middleware/TestMiddleware.py
@@ -1,0 +1,10 @@
+class TestMiddleware:
+    ''' Test Middleware '''
+
+    def __init__(self, Request):
+        ''' Inject Any Dependencies From The Service Container '''
+        self.request = Request
+
+    def before(self):
+        ''' Run This Middleware Before The Route Executes '''
+        self.request.path = '/test/middleware'

--- a/masonite/middleware/CsrfMiddleware.py
+++ b/masonite/middleware/CsrfMiddleware.py
@@ -1,0 +1,48 @@
+''' CSRF Middleware '''
+from masonite.exceptions import InvalidCSRFToken
+
+
+class CsrfMiddleware:
+    ''' Verify CSRF Token Middleware '''
+
+    exempt = ['/']
+
+    def __init__(self, Request, Csrf, ViewClass):
+        self.request = Request
+        self.csrf = Csrf
+        self.view = ViewClass
+
+    def before(self):
+        token = self.__verify_csrf_token()
+
+        self.view.share({
+            'csrf_field': "<input type='hidden' name='__token' value='{0}' />".format(token)
+        })
+
+    def after(self):
+        pass
+
+    def __in_exempt(self):
+        """
+        Determine if the request has a URI that should pass
+        through CSRF verification.
+        """
+
+        if self.request.path in self.exempt:
+            return True
+        else:
+            return False
+
+    def __verify_csrf_token(self):
+        """
+        Verify si csrf token in post is valid.
+        """
+
+        if self.request.is_post() and not self.__in_exempt():
+            token = self.request.input('__token')
+            if not self.csrf.verify_csrf_token(token):
+                raise InvalidCSRFToken("Invalid CSRF token.")
+        else:
+            token = self.csrf.generate_csrf_token()
+
+        return token

--- a/masonite/providers/RouteProvider.py
+++ b/masonite/providers/RouteProvider.py
@@ -1,7 +1,6 @@
 """ A RouteProvider Service Provider """
 import re
 import json
-from pydoc import locate
 
 from masonite.provider import ServiceProvider
 from masonite.view import View
@@ -81,7 +80,7 @@ class RouteProvider(ServiceProvider):
 
                 for http_middleware in self.app.make('HttpMiddleware'):
                     located_middleware = self.app.resolve(
-                        locate(http_middleware)
+                        http_middleware
                     )
                     if hasattr(located_middleware, 'before'):
                         located_middleware.before()
@@ -142,7 +141,7 @@ class RouteProvider(ServiceProvider):
 
                 for http_middleware in self.app.make('HttpMiddleware'):
                     located_middleware = self.app.resolve(
-                        locate(http_middleware)
+                        http_middleware
                     )
                     if hasattr(located_middleware, 'after'):
                         located_middleware.after()

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -3,8 +3,6 @@ import cgi
 import importlib
 import json
 
-from pydoc import locate
-
 from config import middleware
 from masonite.exceptions import RouteMiddlewareNotFound
 
@@ -41,11 +39,13 @@ class Route():
         if self.is_not_get_request():
             if 'CONTENT_TYPE' in self.environ and 'application/json' in self.environ['CONTENT_TYPE']:
                 try:
-                    request_body_size = int(self.environ.get('CONTENT_LENGTH', 0))
+                    request_body_size = int(
+                        self.environ.get('CONTENT_LENGTH', 0))
                 except (ValueError):
                     request_body_size = 0
 
-                request_body = self.environ['wsgi.input'].read(request_body_size)
+                request_body = self.environ['wsgi.input'].read(
+                    request_body_size)
                 return {'payload': json.loads(request_body)}
             else:
                 fields = cgi.FieldStorage(
@@ -114,7 +114,7 @@ class BaseHttpRoute:
         self._find_controller(output)
         self.route_url = route
         return self
-    
+
     def _find_controller(self, controller):
         # If the output specified is a string controller
         if isinstance(controller, str):
@@ -123,11 +123,11 @@ class BaseHttpRoute:
             if mod[0].startswith('/'):
                 self.module_location = '.'.join(
                     mod[0].replace('/', '').split('.')[0:-1])
-        
+
         else:
             if controller is None:
                 return None
-            
+
             fully_qualified_name = controller.__qualname__
             mod = fully_qualified_name.split('.')
             self.module_location = controller.__module__
@@ -191,9 +191,11 @@ class BaseHttpRoute:
 
             # Locate the middleware based on the string specified
             try:
-                located_middleware = self.request.app().resolve(locate(self.request.app().make('RouteMiddleware')[arg]))
+                located_middleware = self.request.app().resolve(
+                    self.request.app().make('RouteMiddleware')[arg])
             except KeyError:
-                raise RouteMiddlewareNotFound("Could not find the '{0}' route middleware".format(arg))
+                raise RouteMiddlewareNotFound(
+                    "Could not find the '{0}' route middleware".format(arg))
 
             # If the middleware has the specific type of middleware
             # (before or after) then execute that
@@ -232,38 +234,38 @@ class Delete(BaseHttpRoute):
     def __init__(self):
         self.method_type = 'DELETE'
 
+
 class RouteGroup():
-    
+
     def __new__(self, routes=[], middleware=[], domain=[], prefix='', name=''):
         from masonite.helpers.routes import flatten_routes
-        
+
         self.routes = flatten_routes(routes)
 
         if middleware:
             self._middleware(self, *middleware)
-        
+
         if domain:
             self._domain(self, domain)
-        
+
         if prefix:
             self._prefix(self, prefix)
-        
+
         if name:
             self._name(self, name)
 
         return self.routes
 
-
     def _middleware(self, *middleware):
         for route in self.routes:
             route.middleware(*middleware)
-        
+
         return self.routes
 
     def _domain(self, domain):
         for route in self.routes:
             route.domain(domain)
-    
+
     def _prefix(self, prefix):
         for route in self.routes:
             route.route_url = prefix + route.route_url

--- a/masonite/testsuite/__init__.py
+++ b/masonite/testsuite/__init__.py
@@ -1,3 +1,4 @@
 from .TestRequest import TestRequest
 from .TestRoute import TestRoute
 from .TestSuite import TestSuite
+from .TestSuite import generate_wsgi

--- a/masonite/view.py
+++ b/masonite/view.py
@@ -52,7 +52,7 @@ class View:
         # Check if composers are even set for a speed improvement
         if self.composers:
             self._update_from_composers()
-        print(self.filename)
+            
         self.rendered_template = self.env.get_template(self.filename).render(
             self.dictionary)
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'masonite.queues',
         'masonite.contracts',
         'masonite.helpers',
+        'masonite.middleware',
     ],
     version=VERSION,
     install_requires=[

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,47 @@
+from masonite.app import App
+from masonite.request import Request
+from masonite.view import View
+from masonite.routes import Get, Route
+from masonite.testsuite import generate_wsgi
+from masonite.auth import Csrf
+from masonite.providers import RouteProvider
+from app.http.middleware.TestMiddleware import TestMiddleware as MiddlewareTest
+from app.http.middleware.TestHttpMiddleware import TestHttpMiddleware as MiddlewareHttpTest
+
+class TestMiddleware:
+
+    def setup_method(self):
+        self.app = App()
+        self.app.bind('Environ', generate_wsgi())
+        self.app.make('Environ')
+        self.app.bind('Headers', [])
+        self.app.bind('Request', Request(self.app.make('Environ')).load_app(self.app))
+        self.app.bind('Csrf', Csrf(self.app.make('Request')))
+        self.app.bind('Route', Route(self.app.make('Environ')))
+
+        self.app.bind('ViewClass', View(self.app))
+
+        self.app.bind('WebRoutes', [
+            Get().route('/', 'TestController@show').middleware('test')
+        ])
+
+        self.app.bind('HttpMiddleware', [
+            MiddlewareHttpTest
+        ])
+        self.app.bind('RouteMiddleware', {
+            'test': MiddlewareTest
+        })
+
+        self.provider = RouteProvider()
+        self.provider.app = self.app
+    
+    def test_route_middleware_runs(self):
+        self.app.resolve(self.provider.boot)
+        assert self.app.make('Request').path == '/test/middleware'
+
+    def test_http_middleware_runs(self):
+        self.app.resolve(self.provider.boot)
+        assert self.app.make('Request').path == '/test/middleware'
+        assert self.app.make('Request').environ['HTTP_TEST'] == 'test'
+
+

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -215,6 +215,7 @@ class TestView:
         view = self.container.make('View')
 
         assert 'John' in view('mail.welcome', {'to': 'John'}).rendered_template
+        assert 'John' in view('mail/welcome', {'to': 'John'}).rendered_template
 
         self.container.make('ViewClass').set_splice('@')
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -220,4 +220,4 @@ class TestView:
         self.container.make('ViewClass').set_splice('@')
 
         assert 'John' in view('mail@welcome', {'to': 'John'}).rendered_template
-
+        assert 'John' in view('mail/welcome', {'to': 'John'}).rendered_template


### PR DESCRIPTION
This PR removes middleware as strings. You must now import the classes and is them directly.

This changes this:

```python
HTTP_MIDDLEWARE = [
    'app.http.middleware.LoadUserMiddleware.LoadUserMiddleware',
    'app.http.middleware.CsrfMiddleware.CsrfMiddleware',
]
```

into this:

```python
from app.http.middleware import LoadUserMiddleware, CsrfMiddleware


HTTP_MIDDLEWARE = [
    LoadUserMiddleware,
    CsrfMiddleware,
]
```

This is also true for route middleware as well.