### PR TITLE
added ability to have dot notation

### DIFF
--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -80,7 +80,7 @@ class Route():
                     regex += r'([a-zA-Z]+)'
                 else:
                     # default
-                    regex += r'(\w+)'
+                    regex += r'([\w.]+)'
                 regex += r'\/'
 
                 # append the variable name passed @(variable):int to a list

--- a/tests/providers/test_route_provider.py
+++ b/tests/providers/test_route_provider.py
@@ -82,6 +82,20 @@ class TestRouteProvider:
 
         assert self.app.make('Request').param('id') == '1'
     
+    def test_url_with_dots_finds_route(self):
+        self.app.make('Route').url = '/test/user.endpoint'
+        self.app.bind('WebRoutes', [get('/test/@endpoint', ControllerTest.show)])
+
+        self.provider.boot(
+            self.app.make('WebRoutes'),
+            self.app.make('Route'),
+            self.app.make('Request'),
+            self.app.make('Environ'),
+            self.app.make('Headers'),
+        )
+
+        assert self.app.make('Request').param('endpoint') == 'user.endpoint'
+    
     def test_route_subdomain_ignores_routes(self):
         self.app.make('Route').url = '/test'
         self.app.make('Environ')['HTTP_HOST'] = 'subb.domain.com'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -33,7 +33,7 @@ class TestRoutes:
     def test_compile_route_to_regex(self):
         assert self.route.compile_route_to_regex(Get().route('test/route', None)) == '^test\\/route\\/$'
         assert self.route.compile_route_to_regex(Get().route(
-            'test/@route', None)) == '^test\\/(\\w+)\\/$'
+            'test/@route', None)) == '^test\\/([\\w.]+)\\/$'
 
         assert self.route.compile_route_to_regex(Get().route(
             'test/@route:int', None)) == '^test\\/(\\d+)\\/$'


### PR DESCRIPTION
This PR adds ability to have dot notation routes. Previously the regex was not compiling to allow `.` as an endpoint.

Previously you were not able to have a route like: `/endpoint/user.profile` since the regex was compiling only alpha numeric and not `.`.

This PR adds the ability to have those dot notation routes