### PR TITLE
hotfix autoloader

### DIFF
--- a/masonite/autoload.py
+++ b/masonite/autoload.py
@@ -49,7 +49,7 @@ class Autoload:
             for obj in inspect.getmembers(self._get_module_members(module_loader, name)):
 
                 # If the object is a class and the objects module starts with the search path
-                if inspect.isclass(obj[1]) and obj[1].__module__.startswith(search_path.replace('/', '.')):
+                if inspect.isclass(obj[1]) and obj[1].__module__.split('.')[:-1] == search_path.split('/'):
                     if self.app.has(obj[1].__name__) and not self.app.make(obj[1].__name__).__module__.startswith(search_path):
                         raise AutoloadContainerOverwrite(
                             'Container already has the key: {}. Cannot overwrite a container key that exists outside of your application.'.format(obj[1].__name__))

--- a/masonite/info.py
+++ b/masonite/info.py
@@ -1,4 +1,4 @@
 """Module for specifying the Masonite version in a central location.
 """
 
-VERSION = '2.0.16'
+VERSION = '2.0.17'


### PR DESCRIPTION
This PR fixes an issue where the autoloader is loading in more directories than it's supposed to. 

We have an autoload by default that looks like this:

```
AUTOLOAD = [
    'app'
]
```

which should pull in all classes inside the `app` directory. But it was actually pulling in all classes also inside my `app/events` directory. and even `app/providers` directory.

This PR fixes that issue and now it only loads objects inside the directory it is being called in.