### PR TITLE
removed payload from incoming json requests

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -174,7 +174,6 @@ class Request(Extendable):
         self.method = environ['REQUEST_METHOD']
         self.path = environ['PATH_INFO']
         self.request_variables = {}
-
         self._set_standardized_request_variables(environ['QUERY_STRING'])
 
         if self.has('__method'):
@@ -189,8 +188,13 @@ class Request(Extendable):
             variables {string|dict}
         """
 
+        if isinstance(variables, dict):
+            self.request_variables = variables
+            return
+
         if isinstance(variables, str):
             variables = parse_qs(variables)
+
 
         for name in variables.keys():
             value = self._get_standardized_value(variables[name])
@@ -205,7 +209,6 @@ class Request(Extendable):
         Returns:
             string|bool
         """
-
         if isinstance(value, list):
             return value[0]
 

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -87,7 +87,7 @@ class Route:
 
                 request_body = self.environ['wsgi.input'].read(
                     request_body_size)
-                return {'payload': json.loads(request_body)}
+                return json.loads(request_body)
             else:
                 fields = cgi.FieldStorage(
                     fp=self.environ['wsgi.input'], environ=self.environ, keep_blank_values=1)

--- a/tests/test_extends.py
+++ b/tests/test_extends.py
@@ -28,7 +28,7 @@ class ExtendClass2:
 class MockWsgiInput():
 
     def read(self, value):
-        return '{"id": 1}'
+        return '{"id": 1, "test": "testing"}'
 
 
 def get_third_path(self):
@@ -105,9 +105,9 @@ class TestExtends:
         json_wsgi['CONTENT_TYPE'] = 'application/json'
         json_wsgi['QUERY_STRING'] = ''
         json_wsgi['wsgi.input'] = MockWsgiInput()
-
         Route(json_wsgi)
         request_obj = Request(json_wsgi)
 
         assert isinstance(request_obj.request_variables, dict)
-        assert request_obj.input('payload') == {'id': 1}
+        assert request_obj.input('id') == 1
+        assert request_obj.input('test') == 'testing'


### PR DESCRIPTION
This PR fixes the weird `payload` input that is required to get the request inputs for incoming json requests.

Previously we had to do this:

```python
def show(self):
    request().input('payload')['some_input']
```

now we just straight up grab the input we need:

```python
def show(self):
    request().input('some_input')
```