### PR TITLE
add craft share command

### DIFF
--- a/masonite/commands/ShareCommand.py
+++ b/masonite/commands/ShareCommand.py
@@ -1,0 +1,30 @@
+from cleo import Command
+import shutil
+import subprocess
+
+
+class ShareCommand(Command):
+    """
+    Strats a ngrok tunnel
+
+    share
+        {--port=8000 : Specify which port to run the server}
+        {--host=127.0.0.1 : Specify which ip address to run the server}
+        {--path=ngrok : Specify which ngrok executable path to run the ngrok}
+    """
+
+    def handle(self):
+        ngrok = self.option('path')
+        port = self.option('port')
+        host = self.option('host')
+
+        if shutil.which(ngrok) is not None:
+            start_ngrok = subprocess.Popen(
+                '{ngrok} http {host}:{port}'.format(ngrok=ngrok, host=host, port=port),
+                shell=True)
+            subprocess.call(
+                'craft serve --port {port} --host {host}'.format(
+                    port=port, host=host),
+                shell=True)
+        else:
+            self.error('ngrok: command not found')

--- a/masonite/commands/__init__.py
+++ b/masonite/commands/__init__.py
@@ -19,4 +19,5 @@ from .ValidatorCommand import ValidatorCommand
 from .RoutesCommand import RoutesCommand
 from .SeedCommand import SeedCommand
 from .SeedRunCommand import SeedRunCommand
+from .ShareCommand import ShareCommand
 from .TinkerCommand import TinkerCommand

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -10,7 +10,8 @@ from masonite.commands import (AuthCommand, CommandCommand, ControllerCommand,
                                MigrateResetCommand, MigrateRollbackCommand,
                                ModelCommand, ProviderCommand, RoutesCommand,
                                SeedCommand, SeedRunCommand, ServeCommand,
-                               TinkerCommand, ViewCommand, ValidatorCommand)
+                               ShareCommand, TinkerCommand, ViewCommand,
+                               ValidatorCommand,)
 
 from masonite.exception_handler import ExceptionHandler
 from masonite.helpers.routes import flatten_routes
@@ -57,6 +58,7 @@ class AppProvider(ServiceProvider):
         self.app.bind('MasoniteServeCommand', ServeCommand())
         self.app.bind('MasoniteSeedCommand', SeedCommand())
         self.app.bind('MasoniteSeedRunCommand', SeedRunCommand())
+        self.app.bind('MasoniteShareCommand', ShareCommand())
         self.app.bind('MasoniteTinkerCommand', TinkerCommand())
         self.app.bind('MasoniteValidatorCommand', ValidatorCommand())
 


### PR DESCRIPTION
`craft share` command starts a `ngrok` tunnel. 

`craft share` can be run with the following options.
```
  --port=8000 : Specify which port to run the server
  --host=127.0.0.1 : Specify which ip address to run the server
  --path=ngrok : Specify which ngrok executable path to run the ngrok 
```

Example running th command.
`$ craft share --port 5000 --path ~/Downloads/ngrok`

Closes #205 

