### PR TITLE
added base support for using full routes

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -15,11 +15,12 @@ from urllib.parse import parse_qs
 import tldextract
 from cryptography.fernet import InvalidToken
 
+from config import application
 from masonite.auth.Sign import Sign
+from masonite.helpers import dot
 from masonite.helpers.Extendable import Extendable
 from masonite.helpers.routes import compile_route_to_regex
 from masonite.helpers.time import cookie_expire_time
-from masonite.helpers import dot
 
 
 class Request(Extendable):
@@ -533,8 +534,6 @@ class Request(Extendable):
             self
         """
 
-        web_routes = self.container.make('WebRoutes')
-
         self.redirect_url = self._get_named_route(route_name, params)
 
         return self
@@ -600,7 +599,7 @@ class Request(Extendable):
 
         return self.compile_route_to_url(self._get_route_from_controller(controller).route_url, params)
 
-    def route(self, name, params={}):
+    def route(self, name, params={}, full=False):
         """Gets a route URI by its name.
 
         Arguments:
@@ -613,7 +612,8 @@ class Request(Extendable):
             masonite.routes.Route|None -- Returns None if the route cannot be found.
         """
 
-        web_routes = self.container.make('WebRoutes')
+        if full:
+            return application.URL + self._get_named_route(name, params)
 
         return self._get_named_route(name, params)
 

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -607,6 +607,7 @@ class Request(Extendable):
 
         Keyword Arguments:
             params {dict} -- Dictionary of parameters to pass to the route for compilation. (default: {{}})
+            full {bool} -- Specifies whether the full application url should be returned or not. (default: {False})
 
         Returns:
             masonite.routes.Route|None -- Returns None if the route cannot be found.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -52,14 +52,13 @@ class TestCache:
         cache_driver = self.app.make('Cache')
 
         cache_driver.store('key', 'value')
-        cache_driver.store_for('key_time', 'key value', 2, 'seconds')
-
         assert cache_driver.get('key') == 'value'
+
+        cache_driver.store_for('key_time', 'key value', 4, 'seconds')
         assert cache_driver.get('key_time') == 'key value'
 
-
-        for cache_file in glob.glob('bootstrap/cache/key*'):
-            os.remove(cache_file)
+        cache_driver.delete('key')
+        cache_driver.delete('key_time')
 
     def test_cache_expired_before_get(self):
         cache_driver = self.app.make('Cache')

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -264,6 +264,17 @@ class TestRequest:
         assert request.route('test.url') == '/test/url'
         assert request.route('test.id', {'id': 1}) == '/test/url/1'
 
+    def test_request_route_returns_full_url(self):
+        app = App()
+        app.bind('Request', self.request)
+        app.bind('WebRoutes', [
+            get('/test/url', None).name('test.url'),
+            get('/test/url/@id', None).name('test.id')
+        ])
+        request = app.make('Request').load_app(app)
+
+        assert request.route('test.url', full=True) == 'http://localhost/test/url'
+
     def test_redirect_compiles_url_with_multiple_slashes(self):
         app = App()
         app.bind('Request', self.request)


### PR DESCRIPTION
This adds support for adding "full" urls using the route method on the request class.

A code example would be this:

```python
def show(self, request: Request):
    request.route('dashboard.user') # /dashboard/user
    request.route('dashboard.user', full=True) # http://localhost:8000/dashboard/user
    request.route('dashboard.user', {'id': 1}) # /dashboard/user/1
    request.route('dashboard.user', {'id': 1}, full=True) # http://localhost:8000/dashboard/user/1
    request.route('dashboard.user', {'id': 1}, True) # http://localhost:8000/dashboard/user/1

```

Closes #329 