### PR TITLE
Add `port` dictionary key

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -32,6 +32,7 @@ DATABASES = {
     'default': {
         'driver': os.environ.get('DB_DRIVER'),
         'host': os.environ.get('DB_HOST'),
+        'port': os.environ.get('DB_PORT'),
         'database': os.environ.get('DB_DATABASE'),
         'user': os.environ.get('DB_USERNAME'),
         'password': os.environ.get('DB_PASSWORD'),


### PR DESCRIPTION
This kept me busy for the past hour trying to connect to my Postgres instance. I kept getting connection errors when trying to `craft migrate`. I assumed the environment varialbe `DB_PORT` was included in the `config/database.py`, but it wasn't
I added support for non-standard database ports to `config/database.py`