### PR TITLE
Class name already contained Controller

### DIFF
--- a/masonite/snippets/scaffold/controller.html
+++ b/masonite/snippets/scaffold/controller.html
@@ -2,7 +2,7 @@
 
 
 class {{ class }}:
-    """{{ class }} Controller
+    """{{ class }}
     """
 
     def show(self):


### PR DESCRIPTION
Don't need `Controller` in the doc strings as Class name already has `controller` in it