### PR TITLE
Add amqp queue driver

### DIFF
--- a/masonite/commands/QueueWorkCommand.py
+++ b/masonite/commands/QueueWorkCommand.py
@@ -1,5 +1,7 @@
 """ A QueueWorkCommand Command """
+
 import pickle
+import inspect
 
 from cleo import Command
 
@@ -10,7 +12,9 @@ from masonite.exceptions import DriverLibraryNotFound
 
 def callback(ch, method, properties, body):
     from wsgi import container
-    job = container.resolve(pickle.loads(body))
+    job = pickle.loads(body)
+    if inspect.isclass(job):
+        job = container.resolve(job)
     job.handle()
     ch.basic_ack(delivery_tag=method.delivery_tag)
 

--- a/masonite/commands/QueueWorkCommand.py
+++ b/masonite/commands/QueueWorkCommand.py
@@ -25,9 +25,7 @@ class QueueWorkCommand(Command):
 
     queue:work
         {--c|channel=default : The channel to listen on the queue}
-        {--e|exchange=default : The channel to listen on the queue}
         {--f|fair : Send jobs to queues that have no jobs instead of randomly selecting a queue}
-        {--d|durable : Send jobs to queues that have no jobs instead of randomly selecting a queue}
     """
 
     def handle(self):
@@ -50,5 +48,5 @@ class QueueWorkCommand(Command):
             channel.basic_qos(prefetch_count=1)
 
         self.info(' [*] Waiting to process jobs on the "{}" channel. To exit press CTRL+C'.format(
-            self.option('channel'), self.option('exchange')))
+            self.option('channel')))
         channel.start_consuming()

--- a/masonite/commands/QueueWorkCommand.py
+++ b/masonite/commands/QueueWorkCommand.py
@@ -1,12 +1,11 @@
 """ A QueueWorkCommand Command """
 
-import pickle
 import inspect
+import pickle
 
 from cleo import Command
 
 from config import queue
-
 from masonite.exceptions import DriverLibraryNotFound
 
 

--- a/masonite/commands/QueueWorkCommand.py
+++ b/masonite/commands/QueueWorkCommand.py
@@ -21,7 +21,7 @@ def callback(ch, method, properties, body):
 
 class QueueWorkCommand(Command):
     """
-    Description of command
+    Start the queue worker
 
     queue:work
         {--c|channel=default : The channel to listen on the queue}

--- a/masonite/commands/QueueWorkCommand.py
+++ b/masonite/commands/QueueWorkCommand.py
@@ -1,0 +1,50 @@
+""" A QueueWorkCommand Command """
+import pickle
+
+from cleo import Command
+
+from config import queue
+
+from masonite.exceptions import DriverLibraryNotFound
+
+
+def callback(ch, method, properties, body):
+    from wsgi import container
+    job = container.resolve(pickle.loads(body))
+    job.handle()
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+
+class QueueWorkCommand(Command):
+    """
+    Description of command
+
+    queue:work
+        {--c|channel=default : The channel to listen on the queue}
+        {--e|exchange=default : The channel to listen on the queue}
+        {--f|fair : Send jobs to queues that have no jobs instead of randomly selecting a queue}
+        {--d|durable : Send jobs to queues that have no jobs instead of randomly selecting a queue}
+    """
+
+    def handle(self):
+        try:
+            import pika
+        except ImportError:
+            raise DriverLibraryNotFound(
+                "Could not find the 'pika' library. Run pip install pika to fix this.")
+
+        connection = pika.BlockingConnection(pika.URLParameters('amqp://{}:{}@{}:{}/%2F'.format(
+            queue.DRIVERS['amqp']['username'], queue.DRIVERS['amqp']['password'], queue.DRIVERS['amqp']['host'], queue.DRIVERS['amqp']['port'],
+        )))
+        channel = connection.channel()
+
+        channel.queue_declare(queue=self.option('channel'), durable=True)
+
+        channel.basic_consume(callback,
+                              queue=self.option('channel'))
+        if self.option('fair'):
+            channel.basic_qos(prefetch_count=1)
+
+        self.info(' [*] Waiting to process jobs on the "{}" channel. To exit press CTRL+C'.format(
+            self.option('channel'), self.option('exchange')))
+        channel.start_consuming()

--- a/masonite/commands/__init__.py
+++ b/masonite/commands/__init__.py
@@ -12,6 +12,7 @@ from .MigrateResetCommand import MigrateResetCommand
 from .MigrateRollbackCommand import MigrateRollbackCommand
 from .ModelCommand import ModelCommand
 from .ProviderCommand import ProviderCommand
+from .QueueWorkCommand import QueueWorkCommand
 from .ServeCommand import ServeCommand
 from .ViewCommand import ViewCommand
 from .ValidatorCommand import ValidatorCommand

--- a/masonite/drivers/QueueAmqpDriver.py
+++ b/masonite/drivers/QueueAmqpDriver.py
@@ -1,7 +1,6 @@
 import pickle
 import threading
 
-
 from config import queue
 from masonite.contracts import QueueContract
 from masonite.drivers import BaseDriver
@@ -17,7 +16,7 @@ class QueueAmqpDriver(QueueContract, BaseDriver):
 
     def __init__(self, Container):
         """Queue AMQP Driver
-        
+
         Arguments:
             Container {masonite.app.App} -- The application container.
         """
@@ -50,8 +49,8 @@ class QueueAmqpDriver(QueueContract, BaseDriver):
         for obj in objects:
             # Publish to the channel for each object
             self.channel.basic_publish(exchange='',
-                                  routing_key=listening_channel,
-                                  body=pickle.dumps(obj),
-                                  properties=self.pika.BasicProperties(
-                                      delivery_mode=2,  # make message persistent
-                                  ))
+                                       routing_key=listening_channel,
+                                       body=pickle.dumps(obj),
+                                       properties=self.pika.BasicProperties(
+                                           delivery_mode=2,  # make message persistent
+                                       ))

--- a/masonite/drivers/QueueAmqpDriver.py
+++ b/masonite/drivers/QueueAmqpDriver.py
@@ -1,0 +1,47 @@
+import pickle
+import threading
+
+
+from config import queue
+from masonite.contracts import QueueContract
+from masonite.drivers import BaseDriver
+from masonite.exceptions import DriverLibraryNotFound
+
+listening_channel = queue.DRIVERS[queue.DRIVER]['channel']
+
+
+class QueueAmqpDriver(QueueContract, BaseDriver):
+
+    def __init__(self, Container):
+        """Queue Async Driver
+        Arguments:
+            Container {masonite.app.App} -- The application container.
+        """
+        try:
+            import pika
+        except ImportError:
+            raise DriverLibraryNotFound(
+                "Could not find the 'pika' library. Run pip install pika to fix this.")
+
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters('localhost')
+        )
+
+        self.channel = connection.channel()
+
+        self.channel.queue_declare(queue=listening_channel, durable=True)
+
+    def push(self, *objects):
+        """Push objects onto the amqp stack.
+
+        Arguments:
+            objects {*args of objects} - This can be several objects as parameters into this method.
+        """
+
+        for obj in objects:
+            self.channel.basic_publish(exchange='',
+                                  routing_key=listening_channel,
+                                  body=pickle.dumps(obj),
+                                  properties=pika.BasicProperties(
+                                      delivery_mode=2,  # make message persistent
+                                  ))

--- a/masonite/drivers/QueueAmqpDriver.py
+++ b/masonite/drivers/QueueAmqpDriver.py
@@ -16,10 +16,12 @@ else:
 class QueueAmqpDriver(QueueContract, BaseDriver):
 
     def __init__(self, Container):
-        """Queue Async Driver
+        """Queue AMQP Driver
+        
         Arguments:
             Container {masonite.app.App} -- The application container.
         """
+
         try:
             import pika
             self.pika = pika
@@ -27,12 +29,15 @@ class QueueAmqpDriver(QueueContract, BaseDriver):
             raise DriverLibraryNotFound(
                 "Could not find the 'pika' library. Run pip install pika to fix this.")
 
+        # Start the connection
         connection = self.pika.BlockingConnection(
             self.pika.ConnectionParameters('localhost')
         )
 
+        # Get the channel
         self.channel = connection.channel()
 
+        # Declare what queue we are working with
         self.channel.queue_declare(queue=listening_channel, durable=True)
 
     def push(self, *objects):
@@ -43,6 +48,7 @@ class QueueAmqpDriver(QueueContract, BaseDriver):
         """
 
         for obj in objects:
+            # Publish to the channel for each object
             self.channel.basic_publish(exchange='',
                                   routing_key=listening_channel,
                                   body=pickle.dumps(obj),

--- a/masonite/drivers/QueueAmqpDriver.py
+++ b/masonite/drivers/QueueAmqpDriver.py
@@ -1,3 +1,5 @@
+""" Driver for AMQP support """
+
 import pickle
 import threading
 

--- a/masonite/drivers/QueueAsyncDriver.py
+++ b/masonite/drivers/QueueAsyncDriver.py
@@ -1,6 +1,7 @@
 """ Async Driver Method """
 
 import threading
+import inspect
 
 from masonite.contracts.QueueContract import QueueContract
 from masonite.drivers.BaseDriver import BaseDriver
@@ -27,7 +28,9 @@ class QueueAsyncDriver(QueueContract, BaseDriver):
         """
 
         for obj in objects:
-            obj = self.container.resolve(obj)
+            if inspect.isclass(obj):
+                obj = self.container.resolve(obj)
+                
             thread = threading.Thread(
                 target=obj.dispatch(), args=(), kwargs={})
             thread.start()

--- a/masonite/drivers/__init__.py
+++ b/masonite/drivers/__init__.py
@@ -7,6 +7,7 @@ from .CacheDiskDriver import CacheDiskDriver
 from .MailMailgunDriver import MailMailgunDriver
 from .MailSmtpDriver import MailSmtpDriver
 from .QueueAsyncDriver import QueueAsyncDriver
+from .QueueAmqpDriver import QueueAmqpDriver
 from .SessionCookieDriver import SessionCookieDriver
 from .SessionMemoryDriver import SessionMemoryDriver
 from .UploadDiskDriver import UploadDiskDriver

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -8,8 +8,8 @@ from masonite.commands import (AuthCommand, CommandCommand, ControllerCommand,
                                KeyCommand, MakeMigrationCommand,
                                MigrateCommand, MigrateRefreshCommand,
                                MigrateResetCommand, MigrateRollbackCommand,
-                               ModelCommand, ProviderCommand, RoutesCommand,
-                               SeedCommand, SeedRunCommand, ServeCommand,
+                               ModelCommand, ProviderCommand, QueueWorkCommand, 
+                               RoutesCommand, SeedCommand, SeedRunCommand, ServeCommand,
                                TinkerCommand, ViewCommand, ValidatorCommand)
 
 from masonite.exception_handler import ExceptionHandler
@@ -50,6 +50,7 @@ class AppProvider(ServiceProvider):
                       MigrateRollbackCommand())
         self.app.bind('MasoniteModelCommand', ModelCommand())
         self.app.bind('MasoniteProviderCommand', ProviderCommand())
+        self.app.bind('MasoniteQueueWorkCommand', QueueWorkCommand())
         self.app.bind('MasoniteViewCommand', ViewCommand())
         self.app.bind('MasoniteRoutesCommand', RoutesCommand())
         self.app.bind('MasoniteServeCommand', ServeCommand())

--- a/masonite/providers/QueueProvider.py
+++ b/masonite/providers/QueueProvider.py
@@ -1,7 +1,7 @@
 """ A RedirectionProvider Service Provider """
 
 from config import queue
-from masonite.drivers import QueueAsyncDriver
+from masonite.drivers import QueueAsyncDriver, QueueAmqpDriver
 from masonite.managers import QueueManager
 from masonite.provider import ServiceProvider
 
@@ -12,6 +12,7 @@ class QueueProvider(ServiceProvider):
 
     def register(self):
         self.app.bind('QueueAsyncDriver', QueueAsyncDriver)
+        self.app.bind('QueueAmqpDriver', QueueAmqpDriver)
         self.app.bind('QueueManager', QueueManager)
         self.app.bind('QueueConfig', queue)
 


### PR DESCRIPTION
This PR adds support for real message brokers for queues. Currently we just have an async driver which sends jobs into a seperate thread which works pretty well actually but this PR introduces support for any `amqp` standardized message broker like Rabbitmq.

Once this PR gets merged the way to use it will be:

1. install RabbitMQ on your machine (and production machine)
2. change the driver to `amqp` and add the required credentials:

```python
DRIVER = 'amqp'
...
DRIVERS = {
    'amqp': {
        'username': 'guest',
        'password': 'guest',
        'host': 'localhost',
        'port': '5672',
        'channel': 'default',
    }
}
```

3. Start RabbitMQ. Something like:

```bash
$ rabbitmq-server

  ##  ##
  ##  ##      RabbitMQ 3.7.8. Copyright (C) 2007-2018 Pivotal Software, Inc.
  ##########  Licensed under the MPL.  See http://www.rabbitmq.com/
  ######  ##
  ##########  Logs: /usr/local/var/log/rabbitmq/rabbit@localhost.log
                    /usr/local/var/log/rabbitmq/rabbit@localhost_upgrade.log

              Starting broker...
 completed with 6 plugins.
```

which starts the server.

4. Then start the Masonite worker in a separate terminal:

```bash
$ craft queue:work
```

5. Pass jobs into the queue like normal:

```python
from app.jobs import SomeJob
...
def show(self, Queue):
    # do your normal logic
    Queue.push(SomeJob)
```

and you should see them in the worker terminal window:

<img width="536" alt="screen shot 2018-10-04 at 12 03 31 am" src="https://user-images.githubusercontent.com/20172538/46452292-0984ed00-c769-11e8-9842-588d98900547.png">

That's it!