### PR TITLE
added model docstring command

### DIFF
--- a/masonite/commands/ModelDocstringCommand.py
+++ b/masonite/commands/ModelDocstringCommand.py
@@ -1,0 +1,24 @@
+""" A ModelDocstringCommand Command """
+
+from cleo import Command
+
+from config.database import DB
+
+
+class ModelDocstringCommand(Command):
+    """
+    Generate a model docstring based on a table definition
+
+    model:docstring
+        {table : Name of the table to generate the docstring for}
+    """
+
+    def handle(self):
+        conn = DB.get_schema_manager().list_table_columns(self.argument('table'))
+        docstring = '"""Model Definition (generated with love by Masonite) \n\n'
+        for name, column in conn.items():
+            length = '({})'.format(column._length) if column._length else ''
+            docstring += '{}: {}{} default: {}\n'.format(
+                name, column.get_type(), length, column.get_default())
+
+        print(docstring + '"""')

--- a/masonite/commands/__init__.py
+++ b/masonite/commands/__init__.py
@@ -11,6 +11,7 @@ from .MigrateRefreshCommand import MigrateRefreshCommand
 from .MigrateResetCommand import MigrateResetCommand
 from .MigrateRollbackCommand import MigrateRollbackCommand
 from .ModelCommand import ModelCommand
+from .ModelDocstringCommand import ModelDocstringCommand
 from .ProviderCommand import ProviderCommand
 from .ServeCommand import ServeCommand
 from .ViewCommand import ViewCommand

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -9,7 +9,7 @@ from masonite.commands import (AuthCommand, CommandCommand, ControllerCommand,
                                MigrateCommand, MigrateRefreshCommand,
                                MigrateResetCommand, MigrateRollbackCommand,
                                ModelCommand, ModelDocstringCommand, ProviderCommand, RoutesCommand,
-                               SeedCommand, SeedRunCommand, ServeCommand, QueueWorkCommand
+                               SeedCommand, SeedRunCommand, ServeCommand, QueueWorkCommand,
                                TinkerCommand, ViewCommand, ValidatorCommand)
 
 from masonite.exception_handler import ExceptionHandler

--- a/masonite/providers/AppProvider.py
+++ b/masonite/providers/AppProvider.py
@@ -8,7 +8,7 @@ from masonite.commands import (AuthCommand, CommandCommand, ControllerCommand,
                                KeyCommand, MakeMigrationCommand,
                                MigrateCommand, MigrateRefreshCommand,
                                MigrateResetCommand, MigrateRollbackCommand,
-                               ModelCommand, ProviderCommand, RoutesCommand,
+                               ModelCommand, ModelDocstringCommand, ProviderCommand, RoutesCommand,
                                SeedCommand, SeedRunCommand, ServeCommand,
                                TinkerCommand, ViewCommand, ValidatorCommand)
 
@@ -49,6 +49,7 @@ class AppProvider(ServiceProvider):
         self.app.bind('MasoniteMigrateRollbackCommand',
                       MigrateRollbackCommand())
         self.app.bind('MasoniteModelCommand', ModelCommand())
+        self.app.bind('MasoniteModelDocstringCommand', ModelDocstringCommand())
         self.app.bind('MasoniteProviderCommand', ProviderCommand())
         self.app.bind('MasoniteViewCommand', ViewCommand())
         self.app.bind('MasoniteRoutesCommand', RoutesCommand())

--- a/tests/test_mail_log_drivers.py
+++ b/tests/test_mail_log_drivers.py
@@ -53,7 +53,7 @@ class TestMailLogDrivers:
 
         MailManager(self.app).driver('log').to(user).send('Masonite')
 
-        filepath = '{0}/{1}'.format(os.getcwd(), 'mail.log')
+        filepath = '{0}/{1}'.format('bootstrap/mail', 'mail.log')
         self.logfile = open(filepath, 'r')
         file_string = self.logfile.read()
 
@@ -72,6 +72,6 @@ class TestMailLogDrivers:
         if hasattr(self, 'logfile') and self.logfile:
             self.logfile.close()
 
-        filepath = '{0}/{1}'.format(os.getcwd(), 'mail.log')
+        filepath = '{0}/{1}'.format('bootstrap/mail', 'mail.log')
         if os.path.isfile(filepath):
             os.remove(filepath)


### PR DESCRIPTION
This PR adds a new command:

```bash
$ craft model:docstring table_name
```

for me running 

```bash
$ craft model:docstring users
```

generated this:

```python
"""Model Definition (generated with love by Masonite)

id: integer default: None
name: string(255) default: None
email: string(255) default: None
password: string(255) default: None
remember_token: string(255) default: None
created_at: datetime(6) default: CURRENT_TIMESTAMP(6)
updated_at: datetime(6) default: CURRENT_TIMESTAMP(6)
customer_id: string(255) default: None
plan_id: string(255) default: None
is_active: integer default: None
verified_at: datetime default: None
"""
```

Closes #359 