### PR TITLE
remove setting `Content-Length` for 404, 500, 503

### DIFF
--- a/masonite/providers/StatusCodeProvider.py
+++ b/masonite/providers/StatusCodeProvider.py
@@ -40,9 +40,5 @@ class StatusCodeProvider(ServiceProvider):
                 rendered_view = self.app.make('View')('/masonite/snippets/statuscode', {
                     'code': StatusCode
                 }).rendered_template
-            Headers = [
-                ("Content-Length", str(len(rendered_view)))
-            ]
+                
             self.app.bind('Response', rendered_view)
-
-            self.app.bind('Headers', Headers)


### PR DESCRIPTION
This code sets Content-Length Twice

![screenshot 2018-10-10 at 6 24 57 pm](https://user-images.githubusercontent.com/6290791/46737749-f36fb300-ccb9-11e8-8d6f-3d08101fb439.png)
