### PR TITLE
Add env

### DIFF
--- a/masonite/environment.py
+++ b/masonite/environment.py
@@ -45,3 +45,14 @@ class LoadEnvironment:
 
         env_path = str(Path('.') / '.env.{}'.format(env))
         load_dotenv(dotenv_path=env_path, override=override)
+
+def env(value, default=None):
+    env_var = os.getenv(value, default)
+    if env_var.isnumeric():
+        return int(env_var)
+    elif env_var in ('false', 'False'):
+        return False
+    elif env_var in ('true', 'True'):
+        return True
+    else:
+        return env_var

--- a/masonite/environment.py
+++ b/masonite/environment.py
@@ -46,6 +46,7 @@ class LoadEnvironment:
         env_path = str(Path('.') / '.env.{}'.format(env))
         load_dotenv(dotenv_path=env_path, override=override)
 
+
 def env(value, default=None):
     env_var = os.getenv(value, default)
     if env_var.isnumeric():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,4 @@
-from masonite.environment import LoadEnvironment
+from masonite.environment import LoadEnvironment, env
 import os
 
 
@@ -27,3 +27,28 @@ class TestEnvironment:
         LoadEnvironment(only='local')
         assert 'LOCAL' in os.environ
         assert os.environ.get('LOCAL') == 'TEST'
+
+class TestEnv:
+
+    def test_env_returns_numeric(self):
+        os.environ["numeric"] = "1"
+        assert env('numeric') == 1
+
+    def test_env_returns_numeric_with_default(self):
+        os.environ["numeric"] = "1"
+        assert env('na', '1') == 1
+
+    def test_env_returns_bool(self):
+        os.environ["bool"] = "True"
+        assert env('bool') == True
+        os.environ["bool"] = "true"
+        assert env('bool') == True
+        os.environ["bool"] = "False"
+        assert env('bool') == False
+        os.environ["bool"] = "false"
+        assert env('bool') == False
+
+    def test_env_returns_default(self):
+        os.environ["test"] = "1"
+        assert env('na', 'default') == 'default'
+


### PR DESCRIPTION
This PR adds a new `env` function which helps convert environment types to their respective boolean or int values.

we are currently doing this:

```python
import os
...
DATABASES = {
    'default': {
        'driver': os.environ.get('DB_DRIVER', 'default'),
        'host': os.environ.get('DB_HOST', 'default'),
        'port': os.environ.get('DB_PORT', 'default'),
    }
}
```

Now we can do this:


```python
from masonite import env
...
DATABASES = {
    'default': {
        'driver': env('DB_DRIVER', 'default'),
        'host': env('DB_HOST', 'default'),
        'port': env('DB_PORT', 'default'),
    }
}
```

Not only does this shorten things down a bit but it ALSO will type cast as well. So an environment variable of `'3306'` (string) will actually convert to `3306` (int) 

Also an environment variable of `'True'` or `'true'` will convert to the actual boolean of `True`