### PR TITLE
made routes a list

### DIFF
--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -356,7 +356,7 @@ class Get(BaseHttpRoute):
 
     def __init__(self):
         """Get constructor."""
-        self.method_type = 'GET'
+        self.method_type = ['GET']
         self.list_middleware = []
 
 
@@ -365,7 +365,7 @@ class Post(BaseHttpRoute):
 
     def __init__(self):
         """Post constructor."""
-        self.method_type = 'POST'
+        self.method_type = ['POST']
         self.list_middleware = []
 
 
@@ -387,7 +387,7 @@ class Put(BaseHttpRoute):
 
     def __init__(self):
         """Put constructor."""
-        self.method_type = 'PUT'
+        self.method_type = ['PUT']
         self.list_middleware = []
 
 
@@ -396,7 +396,7 @@ class Patch(BaseHttpRoute):
 
     def __init__(self):
         """Patch constructor."""
-        self.method_type = 'PATCH'
+        self.method_type = ['PATCH']
         self.list_middleware = []
 
 
@@ -405,7 +405,7 @@ class Delete(BaseHttpRoute):
 
     def __init__(self):
         """Delete constructor."""
-        self.method_type = 'DELETE'
+        self.method_type = ['DELETE']
         self.list_middleware = []
 
 

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -436,7 +436,7 @@ class ViewRoute(BaseHttpRoute):
 class RouteGroup():
     """Class for specifying Route Groups."""
 
-    def __new__(self, routes=[], middleware=[], domain=[], prefix='', name=''):
+    def __new__(self, routes=[], middleware=[], domain=[], prefix='', name='', add_methods=[]):
         """Call when this class is first called. This is to give the ability to return a value in the constructor.
 
         Keyword Arguments:
@@ -454,6 +454,9 @@ class RouteGroup():
 
         if middleware:
             self._middleware(self, *middleware)
+
+        if add_methods:
+            self._add_methods(self, *add_methods)
 
         if domain:
             self._domain(self, domain)
@@ -474,6 +477,17 @@ class RouteGroup():
         """
         for route in self.routes:
             route.middleware(*middleware)
+
+        return self.routes
+
+    def _add_methods(self, *methods):
+        """Attach more methods to all routes.
+
+        Returns:
+            list -- Returns list of routes.
+        """
+        for route in self.routes:
+            route.method_type.append(*methods)
 
         return self.routes
 

--- a/masonite/testing/MockRoute.py
+++ b/masonite/testing/MockRoute.py
@@ -23,7 +23,7 @@ class MockRoute:
     def contains(self, value):
         wsgi = generate_wsgi()
         wsgi['PATH_INFO'] = self.route.route_url
-        wsgi['REQUEST_METHOD'] = self.route.method_type
+        wsgi['REQUEST_METHOD'] = self.route.method_type[0]
         self.container = self._run_container(wsgi).container
 
         return value in self.container.make('Response')
@@ -31,7 +31,7 @@ class MockRoute:
     def status(self, value=None):
         wsgi = generate_wsgi()
         wsgi['PATH_INFO'] = self.route.route_url
-        wsgi['REQUEST_METHOD'] = self.route.method_type
+        wsgi['REQUEST_METHOD'] = self.route.method_type[0]
         self.container = self._run_container(wsgi).container
 
         if not value:
@@ -56,19 +56,19 @@ class MockRoute:
         return self
 
     def is_post(self):
-        return self.route.method_type == 'POST'
+        return 'POST' in self.route.method_type
 
     def is_get(self):
-        return self.route.method_type == 'GET'
+        return 'GET' in self.route.method_type
 
     def is_put(self):
-        return self.route.method_type == 'PUT'
+        return 'PUT' in self.route.method_type
 
     def is_patch(self):
-        return self.route.method_type == 'PATCH'
+        return 'PATCH' in self.route.method_type
 
     def is_delete(self):
-        return self.route.method_type == 'DELETE'
+        return 'DELETE' in self.route.method_type
 
     def on_bind(self, obj, method):
         self.container.on_bind(obj, method)

--- a/masonite/testing/UnitTest.py
+++ b/masonite/testing/UnitTest.py
@@ -21,13 +21,13 @@ class UnitTest:
 
     def route(self, url, method=False):
         for route in self.container.make('WebRoutes'):
-            if route.route_url == url and (route.method_type == method or not method):
+            if route.route_url == url and (method in route.method_type or not method):
                 return MockRoute(route, self.container)
 
     def routes(self, routes):
         self.container.bind('WebRoutes', self.container.make('WebRoutes') + routes)
 
-    def json(self, url, data, method='POST'):
+    def json(self, url, data, method=['POST']):
         wsgi = generate_wsgi()
         wsgi['PATH_INFO'] = url
         wsgi['CONTENT_TYPE'] = 'application/json'

--- a/tests/test_request_routes.py
+++ b/tests/test_request_routes.py
@@ -34,8 +34,8 @@ class TestRequestRoutes:
         assert get.list_middleware == ['auth', 'middleware']
 
     def test_method_type(self):
-        assert Post().method_type == 'POST'
-        assert Get().method_type == 'GET'
+        assert Post().method_type == ['POST']
+        assert Get().method_type == ['GET']
 
     def test_method_type_sets_domain(self):
         get = Get().domain('test')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -106,6 +106,14 @@ class TestRoutes:
 
         assert routes[0].required_domain == ['www']
 
+    def test_group_adds_methods(self):
+        routes = RouteGroup([
+            Get().route('/test/1', 'TestController@show'),
+            Get().route('/test/2', 'TestController@show')
+        ], add_methods=['OPTIONS'])
+
+        assert routes[0].method_type == ['GET', 'OPTIONS']
+
     def test_group_route_sets_prefix(self):
         routes = RouteGroup([
             Get().route('/test/1', 'TestController@show'),


### PR DESCRIPTION
This PR changes all route methods to lists to best use the new boolean logic in the route provider. In addition there is also a new change of being able to add a specific method type to all methods in a route group:

```python
RouteGroup([
    get(..),
    put(..),
    patch(..),
    post(..),
], add_methods=('OPTIONS',))
```

In addition to all the request methods it handles by default (GET, PUT etc) it will additionally accept the OPTIONS method as well