### PR TITLE
added more classs directly to Masonite namespace

### DIFF
--- a/masonite/__init__.py
+++ b/masonite/__init__.py
@@ -5,3 +5,6 @@ from .managers.QueueManager import Queue
 from .managers.SessionManager import Session
 from .managers.UploadManager import Upload
 from masonite.environment import env
+from .request import Request
+from .view import View
+from .provider import ServiceProvider


### PR DESCRIPTION
added a better import. Now we can alternatively do this:

```python
from masonite.request import Request
from masonite.view import View


def show(self ..):
    ..
```

and do this instead:

```python
from masonite import Request, View

def show(self ..):
    ..
```