### PR TITLE
routes that exist but are the wrong method type throws 405 instead of 404

### DIFF
--- a/masonite/app.py
+++ b/masonite/app.py
@@ -145,8 +145,8 @@ class App:
                     " constructor using the 'resolve_parameters=True' keyword argument.")
         try:
             return obj(*provider_list)
-        except TypeError:
-            raise ContainerError('Tried resolving the too many dependencies.')
+        except TypeError as e:
+            raise ContainerError('Either Tried resolving the too many dependencies or {}'.format(str(e)))
 
     def collect(self, search):
         """Fetch a dictionary of objects using a search query.

--- a/masonite/exception_handler.py
+++ b/masonite/exception_handler.py
@@ -84,7 +84,7 @@ class ExceptionHandler:
                                                }
                                                ).rendered_template
         self._app.bind('Response', rendered_view)
-        request.header('Content-Type', str(len(rendered_view)))
+        request.header('Content-Length', str(len(rendered_view)))
 
 
 class DD:

--- a/masonite/providers/RouteProvider.py
+++ b/masonite/providers/RouteProvider.py
@@ -121,4 +121,9 @@ class RouteProvider(ServiceProvider):
 
         """No Response was found in the for loop so let's set an arbitrary response now.
         """
+        request.status(404)
         self.app.bind('Response', 'Route not found. Error 404')
+        # If the route exists but not the method is incorrect
+        if request.is_status(404) and request.route_exists(request.path):
+            self.app.bind('Response', 'Method not allowed')
+            request.status(405)

--- a/masonite/providers/StatusCodeProvider.py
+++ b/masonite/providers/StatusCodeProvider.py
@@ -30,10 +30,10 @@ class StatusCodeProvider(ServiceProvider):
 
     def boot(self):
         request = self.app.make('Request')
-        if request.get_status_code() == '200 OK':
+        if request.is_status(200):
             return
 
-        if request.get_status_code() in ('500 Internal Server Error', '404 Not Found', '503 Service Unavailable'):
+        if request.get_status() not in (200,301,302):
             if self.app.make('ViewClass').exists('errors/{}'.format(request.get_status_code().split(' ')[0])):
                 rendered_view = self.app.make('View')(
                     'errors/{}'.format(request.get_status_code().split(' ')[0])).rendered_template

--- a/masonite/providers/StatusCodeProvider.py
+++ b/masonite/providers/StatusCodeProvider.py
@@ -33,7 +33,7 @@ class StatusCodeProvider(ServiceProvider):
         if request.is_status(200):
             return
 
-        if request.get_status() not in (200,301,302):
+        if request.get_status() not in (200, 301, 302):
             if self.app.make('ViewClass').exists('errors/{}'.format(request.get_status_code().split(' ')[0])):
                 rendered_view = self.app.make('View')(
                     'errors/{}'.format(request.get_status_code().split(' ')[0])).rendered_template

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -304,21 +304,21 @@ class Request(Extendable):
 
     def is_status(self, code):
         return self._get_status_code_by_value(self.get_status_code()) == code
-    
+
     def route_exists(self, url):
         web_routes = self.container.make('WebRoutes')
 
         for route in web_routes:
             if route.route_url == url:
                 return True
-        
+
         return False
-    
+
     def _get_status_code_by_value(self, value):
         for key, status in self.statuses.items():
             if status == value:
                 return key
-        
+
         return None
 
     def get_status(self):

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -302,6 +302,28 @@ class Request(Extendable):
         """
         return self.app().make('StatusCode')
 
+    def is_status(self, code):
+        return self._get_status_code_by_value(self.get_status_code()) == code
+    
+    def route_exists(self, url):
+        web_routes = self.container.make('WebRoutes')
+
+        for route in web_routes:
+            if route.route_url == url:
+                return True
+        
+        return False
+    
+    def _get_status_code_by_value(self, value):
+        for key, status in self.statuses.items():
+            if status == value:
+                return key
+        
+        return None
+
+    def get_status(self):
+        return self._get_status_code_by_value(self.get_status_code())
+
     def get_request_method(self):
         """Get the current request method.
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -405,6 +405,30 @@ class TestRequest:
         request.status(500)
         assert request.get_status_code() == '500 Internal Server Error'
 
+    def test_request_gets_int_status(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request.status(500)
+        assert request.get_status() == 500
+
+    def test_can_get_code_by_value(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request.status(500)
+        assert request._get_status_code_by_value('500 Internal Server Error') == 500
+
+    def test_is_status_code(self):
+        app = App()
+        app.bind('Request', self.request)
+        request = app.make('Request').load_app(app)
+
+        request.status(500)
+        assert request.is_status(500) == True
+
     def test_request_sets_invalid_int_status_code(self):
         with pytest.raises(InvalidHTTPStatusCode):
             app = App()
@@ -445,6 +469,18 @@ class TestRequest:
 
         request.path = '/test/url/1'
         assert request.is_named_route('test.id', {'id': 1})
+
+    def test_route_exists(self):
+        app = App()
+        app.bind('Request', self.request)
+        app.bind('WebRoutes', [
+            get('/test/url', None).name('test.url'),
+            get('/test/url/@id', None).name('test.id')
+        ])
+        request = app.make('Request').load_app(app)
+
+        assert request.route_exists('/test/url') == True
+        assert request.route_exists('/test/Not') == False
 
     def test_request_url_from_controller(self):
         app = App()


### PR DESCRIPTION
Closes #467 

This PR allows us to throw a 405 Method Not Allowed instead of a 404 route not found if the route exists but is just the wrong method type