### PR TITLE
Add queues to mail

### DIFF
--- a/masonite/drivers/BaseMailDriver.py
+++ b/masonite/drivers/BaseMailDriver.py
@@ -21,6 +21,7 @@ class BaseMailDriver(BaseDriver):
         self.message_subject = 'Subject'
         self.message_body = None
         self.view = view
+        self._queue = False
 
     def to(self, user_email):
         """Set the user email address who you want to send mail to.
@@ -35,6 +36,18 @@ class BaseMailDriver(BaseDriver):
             user_email = user_email.email
 
         self.to_address = user_email
+        return self
+
+    def queue(self):
+        """Set the user email address who you want to send mail to.
+
+        Arguments:
+            user_email {string} -- The user email address.
+
+        Returns:
+            self
+        """
+        self._queue = True
         return self
 
     def template(self, template_name, dictionary={}):

--- a/masonite/drivers/MailMailgunDriver.py
+++ b/masonite/drivers/MailMailgunDriver.py
@@ -17,11 +17,22 @@ class MailMailgunDriver(BaseMailDriver, MailContract):
         Returns:
             requests.post -- Returns the response as a requests object.
         """
+
+        if self.queue:
+            from wsgi import container
+            from masonite import Queue
+            return container.make(Queue).push(self._send_mail, args=(message,))
+        else:
+            return self._send_mail(message)
+
+
+    def _send_mail(self, message):
         if not message:
             message = self.message_body
 
         domain = self.config.DRIVERS['mailgun']['domain']
         secret = self.config.DRIVERS['mailgun']['secret']
+        
         return requests.post(
             "https://api.mailgun.net/v3/{0}/messages".format(domain),
             auth=("api", secret),

--- a/masonite/drivers/MailMailgunDriver.py
+++ b/masonite/drivers/MailMailgunDriver.py
@@ -27,12 +27,20 @@ class MailMailgunDriver(BaseMailDriver, MailContract):
 
 
     def _send_mail(self, message):
+        """Wrapper around sending mail so it can also be used with queues.
+        
+        Arguments:
+            message {string|None} -- The message to be sent passed in from the send method.
+        
+        Returns:
+            requests.post
+        """
         if not message:
             message = self.message_body
 
         domain = self.config.DRIVERS['mailgun']['domain']
         secret = self.config.DRIVERS['mailgun']['secret']
-        
+
         return requests.post(
             "https://api.mailgun.net/v3/{0}/messages".format(domain),
             auth=("api", secret),

--- a/masonite/drivers/MailSmtpDriver.py
+++ b/masonite/drivers/MailSmtpDriver.py
@@ -59,5 +59,7 @@ class MailSmtpDriver(BaseMailDriver, MailContract):
         self.smtp.quit()
     
     def _send_mail(self, *args):
+        """Wrapper around sending mail so it can also be used for queues.
+        """
         self.smtp.sendmail(*args)
         self.smtp.quit()

--- a/tests/test_mailgun_driver.py
+++ b/tests/test_mailgun_driver.py
@@ -1,6 +1,13 @@
-from config import mail
+
 import pytest
 import os
+
+from masonite import env
+from masonite.environment import LoadEnvironment
+
+LoadEnvironment()
+
+
 
 from masonite.app import App
 from masonite.exceptions import DriverNotFound
@@ -8,7 +15,7 @@ from masonite.view import View
 from masonite.managers.MailManager import MailManager
 from masonite.drivers.MailSmtpDriver import MailSmtpDriver as MailDriver
 from masonite.drivers.MailMailgunDriver import MailMailgunDriver as Mailgun
-
+from config import mail
 
 if os.getenv('MAILGUN_SECRET'):
 
@@ -36,3 +43,8 @@ if os.getenv('MAILGUN_SECRET'):
         def test_mail_renders_template(self):
             assert 'MasoniteTesting' in MailManager(self.app).driver('mailgun').to(
                 'idmann509@gmail.com').template('mail/welcome', {'to': 'MasoniteTesting'}).message_body
+
+        def test_mail_sends_with_queue_and_without_queue(self):
+            if env('RUN_MAIL'):
+                assert MailManager(self.app).driver('mailgun').to('idmann509@gmail.com').send('test queue') == None
+                assert MailManager(self.app).driver('mailgun').queue().to('idmann509@gmail.com').send('test queue') == None

--- a/tests/test_managers_mail_manager.py
+++ b/tests/test_managers_mail_manager.py
@@ -2,6 +2,10 @@ import ssl
 
 import pytest
 
+from masonite.environment import LoadEnvironment
+
+LoadEnvironment()
+
 from config import mail
 from masonite.app import App
 from masonite.contracts import MailManagerContract
@@ -11,6 +15,7 @@ from masonite.exceptions import DriverNotFound
 from masonite.managers import MailManager
 from masonite.view import View
 from masonite.contracts import MailContract
+from masonite import env
 
 
 class MailSmtpDriver:
@@ -91,6 +96,18 @@ class TestMailManager:
         self.app.bind('MailSmtpDriver', MailDriver)
 
         assert MailManager(self.app).driver('smtp').to('idmann509@gmail.com').send_from('masonite@masonite.com').from_address == 'masonite@masonite.com'
+
+    def test_send_mail_sends(self):
+        if env('RUN_MAIL'):
+            self.app.bind('MailSmtpDriver', MailDriver)
+
+            assert MailManager(self.app).driver('smtp').to('idmann509@gmail.com').send('hi')
+
+    def test_send_mail_sends_with_queue(self):
+        if env('RUN_MAIL'):
+            self.app.bind('MailSmtpDriver', MailDriver)
+
+            assert MailManager(self.app).driver('smtp').to('idmann509@gmail.com').queue().send('hi') == None
 
     def test_send_mail_with_subject(self):
         self.app.bind('MailSmtpDriver', MailDriver)


### PR DESCRIPTION
This PR adds the ability to use a new `queue()` method on mail sending.

previously we could do this:

```python
def show(self, mail: Mail):
    mail.to('email@email.com').send('message')
```

Now we can optionally pass the queue method:

```python
def show(self, mail: Mail):
    mail.to('email@email.com').queue().send('message')
```