### PR TITLE
fixed acceptfiles issue

### DIFF
--- a/masonite/drivers/UploadDiskDriver.py
+++ b/masonite/drivers/UploadDiskDriver.py
@@ -52,9 +52,9 @@ class UploadDiskDriver(BaseUploadDriver, UploadContract):
         make_directory(location)
 
         if isinstance(fileitem, _io.TextIOWrapper):
-            open(location + filename, 'wb').write(bytes(fileitem.read(), 'utf-8'))
+            open(location, 'wb').write(bytes(fileitem.read(), 'utf-8'))
         else:
-            open(location + filename, 'wb').write(fileitem.file.read())
+            open(location, 'wb').write(fileitem.file.read())
 
         self.file_location = location
 

--- a/masonite/drivers/UploadDiskDriver.py
+++ b/masonite/drivers/UploadDiskDriver.py
@@ -5,6 +5,7 @@ import _io
 
 from masonite.contracts import UploadContract
 from masonite.drivers import BaseUploadDriver
+from masonite.helpers.filesystem import make_directory
 from masonite.app import App
 
 
@@ -45,14 +46,16 @@ class UploadDiskDriver(BaseUploadDriver, UploadContract):
         self.validate_extension(filename)
 
         location = self.get_location(location)
-        if not location.endswith('/'):
-            location += '/'
+
+        location = os.path.join(location, filename)
+
+        make_directory(location)
 
         if isinstance(fileitem, _io.TextIOWrapper):
             open(location + filename, 'wb').write(bytes(fileitem.read(), 'utf-8'))
         else:
             open(location + filename, 'wb').write(fileitem.file.read())
 
-        self.file_location = location + filename
+        self.file_location = location
 
         return filename

--- a/masonite/drivers/UploadS3Driver.py
+++ b/masonite/drivers/UploadS3Driver.py
@@ -63,10 +63,15 @@ class UploadS3Driver(BaseUploadDriver, UploadContract):
 
         s3 = session.resource('s3')
 
+        if location:
+            location = os.path.join(location, filename)
+        else:
+            location = os.path.join(filename)
+
         s3.meta.client.upload_file(
             file_location,
             self.config.DRIVERS['s3']['bucket'],
-            os.path.join(location, filename)
+            location
         )
 
         return filename

--- a/masonite/drivers/UploadS3Driver.py
+++ b/masonite/drivers/UploadS3Driver.py
@@ -38,9 +38,15 @@ class UploadS3Driver(BaseUploadDriver, UploadContract):
         Returns:
             string -- Returns the file name just saved.
         """
+        try:
+            import boto3
+        except ImportError:
+            raise DriverLibraryNotFound(
+                'Could not find the "boto3" library. Please pip install this library by running "pip install boto3"')
+                
         driver = self.upload.driver('disk')
         driver.accept_file_types = self.accept_file_types
-        driver.store(fileitem, location)
+        driver.store(fileitem, filename=filename, location=location)
         file_location = driver.file_location
 
         # use the new filename or get it from the fileitem
@@ -50,11 +56,6 @@ class UploadS3Driver(BaseUploadDriver, UploadContract):
         # Check if is a valid extension
         self.validate_extension(filename)
 
-        try:
-            import boto3
-        except ImportError:
-            raise DriverLibraryNotFound(
-                'Could not find the "boto3" library. Please pip install this library by running "pip install boto3"')
 
         session = boto3.Session(
             aws_access_key_id=self.config.DRIVERS['s3']['client'],

--- a/masonite/drivers/UploadS3Driver.py
+++ b/masonite/drivers/UploadS3Driver.py
@@ -66,7 +66,7 @@ class UploadS3Driver(BaseUploadDriver, UploadContract):
         s3.meta.client.upload_file(
             file_location,
             self.config.DRIVERS['s3']['bucket'],
-            filename
+            os.path.join(location, filename)
         )
 
         return filename

--- a/masonite/drivers/UploadS3Driver.py
+++ b/masonite/drivers/UploadS3Driver.py
@@ -43,10 +43,10 @@ class UploadS3Driver(BaseUploadDriver, UploadContract):
         except ImportError:
             raise DriverLibraryNotFound(
                 'Could not find the "boto3" library. Please pip install this library by running "pip install boto3"')
-                
+
         driver = self.upload.driver('disk')
         driver.accept_file_types = self.accept_file_types
-        driver.store(fileitem, filename=filename, location=location)
+        driver.store(fileitem, filename=filename, location='storage/temp')
         file_location = driver.file_location
 
         # use the new filename or get it from the fileitem
@@ -55,7 +55,6 @@ class UploadS3Driver(BaseUploadDriver, UploadContract):
 
         # Check if is a valid extension
         self.validate_extension(filename)
-
 
         session = boto3.Session(
             aws_access_key_id=self.config.DRIVERS['s3']['client'],

--- a/masonite/info.py
+++ b/masonite/info.py
@@ -1,3 +1,3 @@
 """Module for specifying the Masonite version in a central location."""
 
-VERSION = '2.1.4'
+VERSION = '2.1.5'

--- a/tests/test_upload_manager.py
+++ b/tests/test_upload_manager.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import pytest
 
 from config import application, storage
@@ -47,6 +48,11 @@ class TestUploadManager:
     def test_upload_manager_throws_error_with_incorrect_file_type(self):
         with pytest.raises(UnacceptableDriverType):
             self.app.make('UploadManager').driver(static)
+
+    def test_disk_driver_creates_directory_if_not_exists(self):
+        self.app.make('UploadManager').driver('disk').store(ImageMock(), location="storage/temp")
+        assert os.path.exists('storage/temp')
+        shutil.rmtree('storage/temp')
 
     def test_upload_manager_changes_accepted_files(self):
         self.app.make('UploadManager').driver('disk').accept('yml').accept_file_types == ('yml')

--- a/tests/test_upload_manager.py
+++ b/tests/test_upload_manager.py
@@ -180,5 +180,4 @@ if os.environ.get('S3_BUCKET'):
             assert self.app.make('UploadManager').driver('s3').store(ImageMock(), filename='newname.jpg') == 'newname.jpg'
 
         def test_upload_with_new_filename_and_location_in_s3(self):
-            print(os.environ.get('S3_BUCKET'))
             assert self.app.make('UploadManager').driver('s3').store(ImageMock(), filename='newname.jpg', location='3/2') == 'newname.jpg'

--- a/tests/test_upload_manager.py
+++ b/tests/test_upload_manager.py
@@ -2,6 +2,10 @@ import os
 import shutil
 import pytest
 
+from masonite.environment import LoadEnvironment
+
+LoadEnvironment()
+
 from config import application, storage
 from masonite.app import App
 from masonite.exceptions import DriverNotFound, FileTypeException, UnacceptableDriverType
@@ -9,7 +13,6 @@ from masonite.managers.UploadManager import UploadManager
 from masonite.drivers.UploadDiskDriver import UploadDiskDriver
 from masonite.drivers.UploadS3Driver import UploadS3Driver
 from masonite.helpers import static
-from masonite.environment import LoadEnvironment
 
 
 class TestStaticTemplateHelper:
@@ -137,7 +140,7 @@ class ImageMock():
         return bytes('file read', 'utf-8')
 
 
-LoadEnvironment()
+
 if os.environ.get('S3_BUCKET'):
 
     class TestS3Upload:
@@ -175,3 +178,7 @@ if os.environ.get('S3_BUCKET'):
 
         def test_upload_with_new_filename(self):
             assert self.app.make('UploadManager').driver('s3').store(ImageMock(), filename='newname.jpg') == 'newname.jpg'
+
+        def test_upload_with_new_filename_and_location_in_s3(self):
+            print(os.environ.get('S3_BUCKET'))
+            assert self.app.make('UploadManager').driver('s3').store(ImageMock(), filename='newname.jpg', location='3/2') == 'newname.jpg'


### PR DESCRIPTION
This PR fixes an issue where s3 would throw an exception if the filename and location were both supplied

- This PR also adds the feature that the upload `disk` driver will create the directory if it does not exist
- This PR also makes all Amazon s3 uploads store to a `storage/temp` directory
- Also bumps up the exception thrown higher in the code to prevent failed uploads but successful file storage if the boto3 library is not installed