### PR TITLE
Add dict dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Sentimental Versioning](http://sentimentalversioning.org/).
 
+## [2.1.5](https://github.com/MasoniteFramework/core/releases/tag/v2.1.5) - 2018-01-03
+### Fixed
+- Fixed issue with LoginController not working properly because of incorrectly specified input
+- Fixed issue with view render method storing variables from previous renders
+- Fixed issue with s3 not working properly when using both location and filename
+- Fixed issue with Amazon S3 storing all files in root directory
+
+### Changed
+- Changed how S3 temporarily stores file uploads
+- Changed where the exception is thrown in the s3 driver to prevent a temporary file being saved before uploading if the driver is not installed.
+
+## [2.1.4](https://github.com/MasoniteFramework/core/releases/tag/v2.1.4) - 2018-12-30
+### Fixed
+- Fixed issue where uploading a file resulted in None being returned.
+
 ## [2.1.3](https://github.com/MasoniteFramework/core/releases/tag/v2.1.3) - 2018-12-22
 ### Security
 - Fixed possibility of an XSS attack through query strings

--- a/config/database.py
+++ b/config/database.py
@@ -29,7 +29,7 @@ LoadEnvironment()
 """
 
 DATABASES = {
-    'default': os.environ.get('DB_DRIVER'),
+    'default': os.environ.get('DB_DRIVER', 'sqlite'),
     'sqlite': {
         'driver': 'sqlite',
         'database': os.environ.get('DB_DATABASE'),

--- a/config/storage.py
+++ b/config/storage.py
@@ -36,6 +36,9 @@ DRIVERS = {
         'secret': os.getenv('S3_SECRET', 'HkZj...'),
         'bucket': os.getenv('S3_BUCKET', 's3bucket'),
         'location': 'http://s3.amazon.com/bucket',
+        'test_locations': {
+            'test': 'value'
+        }
     }
 }
 

--- a/masonite/helpers/__init__.py
+++ b/masonite/helpers/__init__.py
@@ -4,3 +4,4 @@ from .validator import validate
 from .misc import random_string, dot, clean_request_input
 from .Extendable import Extendable
 from .time import cookie_expire_time
+from .structures import config, Dot

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -1,3 +1,5 @@
+"""A Module For Manipulating Code Structures."""
+
 import pydoc
 
 
@@ -7,10 +9,13 @@ class Dot:
         """Locate the object from the given search path
 
         Arguments:
-            path {[type]} -- [description]
+            search_path {string} -- A search path to fetch the object from like config.application.debug.
+
+        Keyword Arguments:
+            default {string} -- A default string if the search path is not found (default: {''})
 
         Returns:
-            [type] -- [description]
+            any -- Could be a string, object or anything else that is fetched.
         """
         value = self.find(search_path, default)
 
@@ -21,6 +26,18 @@ class Dot:
             return value
 
     def dict_dot(self, search, dictionary):
+        """Takes a dot notation representation of a dictionary and fetches it from the dictionary.
+
+        This will take something like s3.locations and look into the s3 dictionary and fetch the locations
+        key.
+
+        Arguments:
+            search {string} -- The string to search for in the dictionary using dot notation.
+            dictionary {dict} -- The dictionary to search through.
+
+        Returns:
+            string -- The value of the dictionary element.
+        """
         if "." in search:
             key, rest = search.split(".", 1)
             try:
@@ -36,22 +53,33 @@ class Dot:
         return self.dict_dot(dictionary, search)
 
     def find(self, search_path, default=''):
-        """Used for finding both the uppercase and specified version
+        """Used for finding both the uppercase and specified version.
 
         Arguments:
-            path {string} -- The path to find
+            search_path {string} -- The search path to find the module, dictionary key, object etc. 
+                                    This is typically in the form of dot notation 'config.application.debug'
+
+        Keyword Arguments:
+            default {string} -- The default value to return if the search path could not be found. (default: {''})
+
+        Returns:
+            any -- Could be a string, object or anything else that is fetched.
         """
         value = pydoc.locate(search_path)
+
         if value:
             return value
 
         paths = search_path.split('.')
 
         value = pydoc.locate('.'.join(paths[:-1]) + '.' + paths[-1].upper())
+
         if value:
             return value
 
         search_path = -1
+
+        # Go backwards through the dot notation until a match is found.
         while search_path < len(paths):
             value = pydoc.locate('.'.join(paths[:search_path]) + '.' + paths[search_path].upper())
 

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -1,0 +1,74 @@
+import pydoc
+
+
+class Dot:
+
+    def locate(self, search_path, default=''):
+        """Locate the object from the given search path
+
+        Arguments:
+            path {[type]} -- [description]
+
+        Returns:
+            [type] -- [description]
+        """
+        value = self.find(search_path, default)
+
+        if isinstance(value, dict):
+            return self.dict_dot('.'.join(search_path.split('.')[3:]), value)
+
+        if value is not None:
+            return value
+
+    def dict_dot(self, search, dictionary):
+        if "." in search:
+            key, rest = search.split(".", 1)
+            try:
+                return self.dict_dot(dictionary[key], rest)
+            except (KeyError, TypeError):
+                pass
+        else:
+            try:
+                return dictionary[search]
+            except TypeError:
+                pass
+
+        return self.dict_dot(dictionary, search)
+
+    def find(self, search_path, default=''):
+        """Used for finding both the uppercase and specified version
+
+        Arguments:
+            path {string} -- The path to find
+        """
+        value = pydoc.locate(search_path)
+        if value:
+            return value
+
+        paths = search_path.split('.')
+
+        value = pydoc.locate('.'.join(paths[:-1]) + '.' + paths[-1].upper())
+        if value:
+            return value
+
+        search_path = -1
+        while search_path < len(paths):
+            value = pydoc.locate('.'.join(paths[:search_path]) + '.' + paths[search_path].upper())
+
+            if value:
+                break
+
+            value = pydoc.locate('.'.join(paths[:search_path]) + '.' + paths[search_path])
+
+            if value:
+                break
+            
+            if default:
+                return default
+
+            search_path -= 1
+
+        return value
+
+def config(path, default=''):
+    return Dot().locate(path, default)

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -62,13 +62,14 @@ class Dot:
 
             if value:
                 break
-            
+
             if default:
                 return default
 
             search_path -= 1
 
         return value
+
 
 def config(path, default=''):
     return Dot().locate(path, default)

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -56,7 +56,7 @@ class Dot:
         """Used for finding both the uppercase and specified version.
 
         Arguments:
-            search_path {string} -- The search path to find the module, dictionary key, object etc. 
+            search_path {string} -- The search path to find the module, dictionary key, object etc.
                                     This is typically in the form of dot notation 'config.application.debug'
 
         Keyword Arguments:

--- a/tests/helpers/test_config.py
+++ b/tests/helpers/test_config.py
@@ -1,0 +1,33 @@
+import pydoc
+
+from masonite.helpers import config, Dot
+
+
+class TestConfig:
+
+    def setup_method(self):
+        self.config = config
+
+    def test_config_can_get_value_from_file(self):
+        assert self.config('config.application.DEBUG') == True
+
+    def test_config_can_get_dict_value_lowercase(self):
+        assert self.config('config.application.debug') == True
+
+    def test_config_can_get_dict_default(self):
+        assert self.config('config.sdff.na', 'default') == 'default'
+
+    def test_dict_dot_returns_value(self):
+        assert Dot().dict_dot('s3.test', {'s3': {'test': 'value'}}) == 'value'
+
+    def test_config_can_get_dict_value_inside_dict(self):
+        assert self.config('config.database.DATABASES.default') == 'sqlite'
+
+    def test_config_can_get_dict_value_inside_dict_with_lowercase(self):
+        assert self.config('config.database.databases.default') == 'sqlite'
+
+    def test_config_can_get_dict_inside_dict_inside_dict(self):
+        assert isinstance(self.config('config.database.databases.sqlite'), dict)
+
+    def test_config_can_get_dict_inside_dict_inside_another_dict(self):
+        assert self.config('config.storage.DRIVERS.s3.test_locations.test') == 'value'


### PR DESCRIPTION
This PR adds a new feature called the config helper.

This config helper allows you to fetch configuration values from your application using dot notation rather than importing and fetching information.

To use this helper you will need to import it like so:

```python
from masonite.helpers import config
```

and then use it in a controller to fetch any values from your config. Take this example where you want to check if your application is in debug mode:

```python
from masonite.helpers import config

def show(self):
    if config('config.application.debug'): #== True
        # do something
```

**Notice this is case insensitive. It will look for both `config.application.DEBUG` as well as the lowercase version.**

but whats even cooler is we can actually go an unlimited amount of layers deep into a dictionary:

lets say we have a config like this:

```python
# config/storage.py

DRIVERS = {
    's3': {
        'locations': {
             'west': 'https://west.amazon.com/...',
             'east': 'https://east.amazon.com/...',
         }
    }
}
```

```python
from masonite.helpers import config

def show(self):
    if config('config.storage.drivers.s3.locations.west'): #== 'https://west.amazon.com/...'
        # do something
```

We can also set a default value if none exists:

```python
from masonite.helpers import config

def show(self):
    if config('config.storage.drivers.s3.locations.north', 'http://north.amazon.com/...'):
        # do something
```
