### PR TITLE
fix delete method when body length is 0

### DIFF
--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -86,7 +86,7 @@ class Route:
                 if isinstance(request_body, bytes):
                     request_body = request_body.decode('utf-8')
 
-                return json.loads(request_body)
+                return json.loads(request_body or '{}')
             else:
                 fields = cgi.FieldStorage(
                     fp=self.environ['wsgi.input'], environ=self.environ, keep_blank_values=1)


### PR DESCRIPTION
This route `Delete().route('/api/articles/@slug', 'ArticleController@delete'),` works only when body length in greater than 0, I have added fixed now it works even body length is 0. 

