### PR TITLE
added better exception when passing incorrect parameter type

### DIFF
--- a/masonite/exceptions.py
+++ b/masonite/exceptions.py
@@ -72,3 +72,7 @@ class DebugException(Exception):
 
 class DumpException(Exception):
     pass
+
+
+class ViewException(Exception):
+    pass

--- a/masonite/view.py
+++ b/masonite/view.py
@@ -4,7 +4,7 @@
 from jinja2 import ChoiceLoader, Environment, PackageLoader, select_autoescape
 from jinja2.exceptions import TemplateNotFound
 
-from masonite.exceptions import RequiredContainerBindingNotFound
+from masonite.exceptions import RequiredContainerBindingNotFound, ViewException
 
 
 class View:
@@ -49,6 +49,8 @@ class View:
         Returns:
             self
         """
+        if not isinstance(dictionary, dict):
+            raise ViewException('Second parameter to render method needs to be a dictionary, {} passed.'.format(type(dictionary).__name__))
         self.__load_environment(template)
         self.dictionary = {}
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -7,7 +7,7 @@ from jinja2 import FileSystemLoader, PackageLoader
 from config import cache
 from masonite.app import App
 from masonite.drivers.CacheDiskDriver import CacheDiskDriver
-from masonite.exceptions import RequiredContainerBindingNotFound
+from masonite.exceptions import RequiredContainerBindingNotFound, ViewException
 from masonite.managers.CacheManager import CacheManager
 from masonite.view import View
 
@@ -282,6 +282,11 @@ class TestView:
 
         assert view.render(
             'pug/hello.pug', {'name': 'Joe'}).rendered_template == '<p>hello Joe</p>'
+
+    def test_throws_exception_on_incorrect_type(self):
+        view = self.container.make('ViewClass')
+        # with pytest.raises(ViewException):
+        assert view.render('test', {'', ''})
 
 
 class MockAdminUser:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -285,8 +285,8 @@ class TestView:
 
     def test_throws_exception_on_incorrect_type(self):
         view = self.container.make('ViewClass')
-        # with pytest.raises(ViewException):
-        assert view.render('test', {'', ''})
+        with pytest.raises(ViewException):
+            assert view.render('test', {'', ''})
 
 
 class MockAdminUser:


### PR DESCRIPTION
This PR adds better exception handled. When passing in a value like:

```python
def show(self):
    return view.render('view', {'key', 'value'})
```

which is a common mistake (notice the set passed and not a dictionary) It would throw a key sequence error which was hard to debug. Now it will throw a new exception like:

<img width="1350" alt="screen shot 2019-01-21 at 11 07 09 pm" src="https://user-images.githubusercontent.com/20172538/51512089-2570d500-1dd2-11e9-9b99-214574ca872a.png">

Closes https://github.com/MasoniteFramework/core/issues/533