### PR TITLE
Adds route redirection

### DIFF
--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -438,6 +438,28 @@ class ViewRoute(BaseHttpRoute):
     def get_response(self):
         return self.request.app().make('ViewClass').render(self.template, self.dictionary).rendered_template
 
+class Redirect(BaseHttpRoute):
+
+    def __init__(self, current_route, future_route, status=302, methods=['GET']):
+        """Class used for view routes.
+
+        This class should be returned when a view is called on an HTTP route.
+        This is useful when returning a view that doesn't need any special logic and only needs a dictionary.
+
+        Arguments:
+            method_type {string} -- The method type (GET, POST, PUT etc)
+            route {string} -- The current route (/test/url)
+            template {string} -- The template to use (dashboard/user)
+            dictionary {dict} -- The dictionary to use to render the template.
+        """
+        self.list_middleware = []
+        self.method_type = methods
+        self.route_url = current_route
+        self.status = status
+        self.future_route = future_route
+
+    def get_response(self):
+        return self.request.redirect(self.future_route, status=self.status)
 
 class RouteGroup():
     """Class for specifying Route Groups."""

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -438,6 +438,7 @@ class ViewRoute(BaseHttpRoute):
     def get_response(self):
         return self.request.app().make('ViewClass').render(self.template, self.dictionary).rendered_template
 
+
 class Redirect(BaseHttpRoute):
 
     def __init__(self, current_route, future_route, status=302, methods=['GET']):
@@ -460,6 +461,7 @@ class Redirect(BaseHttpRoute):
 
     def get_response(self):
         return self.request.redirect(self.future_route, status=self.status)
+
 
 class RouteGroup():
     """Class for specifying Route Groups."""

--- a/routes/web.py
+++ b/routes/web.py
@@ -1,10 +1,11 @@
 """ Web Routes """
 from masonite.helpers.routes import group
-from masonite.routes import Get, Post
+from masonite.routes import Get, Post, Redirect
 
 
 ROUTES = [
     Get().route('/test', None).middleware('auth'),
+    Redirect('/redirect', 'test'),
     Get().domain('test').route('/test', None).middleware('auth'),
     Get().domain('test').route('/unit/test', 'TestController@testing').middleware('auth'),
     Get().domain('test').route('/test/route', 'TestController@testing'),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 from masonite.routes import Route
 from masonite.request import Request
-from masonite.routes import Get, Post, Put, Patch, Delete, RouteGroup, Match
+from masonite.app import App
+from masonite.routes import Get, Post, Put, Patch, Delete, RouteGroup, Match, Redirect
 from masonite.helpers.routes import group, flatten_routes
 from masonite.testsuite.TestSuite import generate_wsgi
 from masonite.exceptions import InvalidRouteCompileException, RouteException
@@ -188,6 +189,32 @@ class TestRoutes:
         assert route.environ['QUERY_STRING'] == {
             "options": ["foo", "bar"]
         }
+    
+    def test_redirect_route(self):
+        route = Redirect('/test1', '/test2')
+        request = Request(generate_wsgi())
+        route.load_request(request)
+        request.load_app(App())
+
+        route.get_response()
+        assert request.is_status(302)
+        assert request.redirect_url == '/test2'
+
+    def test_redirect_can_use_301(self):
+        request = Request(generate_wsgi())
+        route = Redirect('/test1', '/test3', status=301)
+        
+        route.load_request(request)
+        request.load_app(App())
+        route.get_response()
+        assert request.is_status(301)
+        assert request.redirect_url == '/test3'
+
+    def test_redirect_can_change_method_type(self):
+        request = Request(generate_wsgi())
+        route = Redirect('/test1', '/test3', methods=['POST', 'PUT'])
+        assert route.method_type == ['POST', 'PUT']
+
 
 class WsgiInputTestClass:
 


### PR DESCRIPTION
This PR introduces the ability to add a route redirection:

```
ROUTES = [
    Get().route(..),
    Post().route(..),
    Redirect('/old/route', '/new/route', status=302, methods=['POST', 'GET']),
]
```

The `status` and `methods` argument is optional and will default to `302` and `['GET']` respectively. 

#545 