### PR TITLE
Add routes and controller to route initializers

### DIFF
--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -360,25 +360,29 @@ class BaseHttpRoute:
 class Get(BaseHttpRoute):
     """Class for specifying GET requests."""
 
-    def __init__(self):
+    def __init__(self, route=None, output=None):
         """Get constructor."""
         self.method_type = ['GET']
         self.list_middleware = []
+        if route and output:
+            self.route(route, output)
 
 
 class Post(BaseHttpRoute):
     """Class for specifying POST requests."""
 
-    def __init__(self):
+    def __init__(self, route=None, output=None):
         """Post constructor."""
         self.method_type = ['POST']
         self.list_middleware = []
+        if route and output:
+            self.route(route, output)
 
 
 class Match(BaseHttpRoute):
     """Class for specifying POST requests."""
 
-    def __init__(self, method_type=['GET']):
+    def __init__(self, method_type=['GET'], route=None, output=None):
         """Post constructor."""
         if not isinstance(method_type, list):
             raise RouteException("Method type needs to be a list. Got '{}'".format(method_type))
@@ -386,33 +390,41 @@ class Match(BaseHttpRoute):
         # Make all method types in list uppercase
         self.method_type = [x.upper() for x in method_type]
         self.list_middleware = []
+        if route and output:
+            self.route(route, output)
 
 
 class Put(BaseHttpRoute):
     """Class for specifying PUT requests."""
 
-    def __init__(self):
+    def __init__(self, route=None, output=None):
         """Put constructor."""
         self.method_type = ['PUT']
         self.list_middleware = []
+        if route and output:
+            self.route(route, output)
 
 
 class Patch(BaseHttpRoute):
     """Class for specifying Patch requests."""
 
-    def __init__(self):
+    def __init__(self, route=None, output=None):
         """Patch constructor."""
         self.method_type = ['PATCH']
         self.list_middleware = []
+        if route and output:
+            self.route(route, output)
 
 
 class Delete(BaseHttpRoute):
     """Class for specifying Delete requests."""
 
-    def __init__(self):
+    def __init__(self, route=None, output=None):
         """Delete constructor."""
         self.method_type = ['DELETE']
         self.list_middleware = []
+        if route and output:
+            self.route(route, output)
 
 
 class ViewRoute(BaseHttpRoute):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -66,6 +66,23 @@ class TestRoutes:
     def test_route_doesnt_break_on_incorrect_controller(self):
         assert Get().route('test/url', 'BreakController@show')
 
+    def test_route_can_pass_route_values_in_constructor(self):
+        route = Get('test/url', 'BreakController@show')
+        assert route.route_url == 'test/url'
+        route = Post('test/url', 'BreakController@show')
+        assert route.route_url == 'test/url'
+        route = Put('test/url', 'BreakController@show')
+        assert route.route_url == 'test/url'
+        route = Patch('test/url', 'BreakController@show')
+        assert route.route_url == 'test/url'
+        route = Delete('test/url', 'BreakController@show')
+        assert route.route_url == 'test/url'
+
+    def test_route_can_pass_route_values_in_constructor_and_use_middleware(self):
+        route = Get('test/url', 'BreakController@show').middleware('auth')
+        assert route.route_url == 'test/url'
+        assert route.list_middleware == ['auth']
+
     def test_route_gets_deeper_module_controller(self):
         route = Get().route('test/url', 'subdirectory.SubController@show')
         assert route.controller


### PR DESCRIPTION
This PR adds the ability to specify routes and controllers in the constructor instead of the normal `.route()` method like so:

```python
ROUTES = [
    Get().route('/some/url', 'Controller@show').middleware(..)
]
```

now becomes:

```python
ROUTES = [
    Get('/some/url', 'Controller@show').middleware(..)
]
```

Both ways are still possible.
Closes #555 
