### PR TITLE
rearranged where cleaning of input happens

### DIFF
--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -36,7 +36,9 @@ def dot(data, compile_to=None):
     return compiling
 
 
-def clean_request_input(value):
+def clean_request_input(value, clean=True):
+    if not clean:
+        return value
     import html
 
     try:

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -5,6 +5,22 @@ import pydoc
 
 class Dot:
 
+    def dot(self, search, dictionary):
+
+        if '.' not in search:
+            return dictionary[search] 
+        
+        searching = search.split('.')
+        while len(searching) > 0:
+            dic = dictionary
+            for search in searching:
+                dic = dic.get(search)
+            
+            if not isinstance(dic, dict):
+                return dic
+
+            del searching[-1]
+
     def locate(self, search_path, default=''):
         """Locate the object from the given search path
 

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -8,14 +8,14 @@ class Dot:
     def dot(self, search, dictionary):
 
         if '.' not in search:
-            return dictionary[search] 
-        
+            return dictionary[search]
+
         searching = search.split('.')
         while len(searching) > 0:
             dic = dictionary
             for search in searching:
                 dic = dic.get(search)
-            
+
             if not isinstance(dic, dict):
                 return dic
 

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -19,7 +19,7 @@ from cryptography.fernet import InvalidToken
 from config import application
 from masonite.auth.Sign import Sign
 from masonite.exceptions import InvalidHTTPStatusCode
-from masonite.helpers import dot, clean_request_input
+from masonite.helpers import dot, clean_request_input, Dot as DictDot
 from masonite.helpers.Extendable import Extendable
 from masonite.helpers.routes import compile_route_to_regex
 from masonite.helpers.status import response_statuses
@@ -76,9 +76,14 @@ class Request(Extendable):
         Returns:
             string
         """
-        if '.' in name:
+        if '.' in name and isinstance(self.request_variables.get(name.split('.')[0]), dict):
+            value = DictDot().dot(name, self.request_variables)
+            if value:
+                return value
+
+        elif '.' in name:
             name = dot(name, "{1}[{.}]")
-        
+
         return clean_request_input(self.request_variables.get(name, default), clean=clean)
 
     def is_post(self):

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -63,7 +63,7 @@ class Request(Extendable):
         self.encryption_key = False
         self.container = None
 
-    def input(self, name, default=False):
+    def input(self, name, default=False, clean=True):
         """Get a specific input value.
 
         Arguments:
@@ -71,13 +71,15 @@ class Request(Extendable):
 
         Keyword Arguments:
             default {string} -- Default value if input does not exist (default: {False})
+            clean {bool} -- Whether or not the return value should be cleaned (default: {True})
 
         Returns:
             string
         """
         if '.' in name:
             name = dot(name, "{1}[{.}]")
-        return self.request_variables.get(name, default)
+        
+        return clean_request_input(self.request_variables.get(name, default), clean=clean)
 
     def is_post(self):
         """Check if the current request is a POST request.
@@ -125,11 +127,12 @@ class Request(Extendable):
         self.encryption_key = key
         return self
 
-    def all(self, internal_variables=True):
+    def all(self, internal_variables=True, clean=True):
         """Get all the input data.
 
         Keyword Arguments:
             internal_variables {bool} -- Get the internal framework variables as well (default: {True})
+            clean {bool} -- Whether or not the return value should be cleaned (default: {True})
 
         Returns:
             dict
@@ -139,9 +142,9 @@ class Request(Extendable):
             for key, value in self.request_variables.items():
                 if not key.startswith('__'):
                     without_internals.update({key: value})
-            return without_internals
+            return clean_request_input(without_internals, clean=clean)
 
-        return self.request_variables
+        return clean_request_input(self.request_variables, clean=clean)
 
     def only(self, *names):
         """Return the specified request variables in a dictionary.
@@ -213,7 +216,7 @@ class Request(Extendable):
 
         try:
             for name in variables.keys():
-                value = clean_request_input(self._get_standardized_value(variables[name]))
+                value = self._get_standardized_value(variables[name])
                 self.request_variables[name.replace('[]', '')] = value
         except TypeError:
             self.request_variables = {}

--- a/tests/helpers/test_dot_notation.py
+++ b/tests/helpers/test_dot_notation.py
@@ -1,5 +1,5 @@
 import pytest
-from masonite.helpers import dot
+from masonite.helpers import dot, Dot as DictDot
 
 
 def test_dot():
@@ -13,3 +13,10 @@ def test_dot():
     assert dot('hey.dot.another', compile_to="/{1}/{.}") == "/hey/dot/another"
     with pytest.raises(ValueError):
         assert dot('hey.dot.another', compile_to="{1}//{.}") == "hey/dot/another"
+
+def test_dict_dot():
+    assert DictDot().dot('key', {'key': 'value'}) == 'value'
+    assert DictDot().dot('key.test', {'key': {'test': 'value'}}) == 'value'
+    assert DictDot().dot('key.test.layer', {'key': {'test': {'layer': 'value'}}}) == 'value'
+    assert DictDot().dot('key.none', {'key': {'test': {'layer': 'value'}}}) == None
+    assert DictDot().dot('key', {'key': {'test': {'layer': 'value'}}}) == {'test': {'layer': 'value'}}

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -374,7 +374,7 @@ class TestRequest:
         route = "http://google.com"
 
         assert request.compile_route_to_url(route) == 'http://google.com'
-    
+
     def test_can_get_nully_value(self):
         app = App()
         app.bind('Request', self.request)
@@ -612,9 +612,25 @@ class TestRequest:
         self.request._set_standardized_request_variables({'key': '<img """><script>alert(\'hey\')</script>">'})
         assert self.request.input('key') == '&lt;img &quot;&quot;&quot;&gt;&lt;script&gt;alert(&#x27;hey&#x27;)&lt;/script&gt;&quot;&gt;'
         assert self.request.input('key', clean=False) == '<img """><script>alert(\'hey\')</script>">'
-    
+
     def test_request_cleans_all_optionally(self):
         self.request._set_standardized_request_variables({'key': '<img """><script>alert(\'hey\')</script>">'})
         assert self.request.all()['key'] == '&lt;img &quot;&quot;&quot;&gt;&lt;script&gt;alert(&#x27;hey&#x27;)&lt;/script&gt;&quot;&gt;'
         assert self.request.all(clean=False)['key'] == '<img """><script>alert(\'hey\')</script>">'
 
+    def test_request_gets_input_with_dotdict(self):
+        self.request.request_variables = {
+            "key": {
+                "user": "1",
+                        "name": "Joe",
+                        "address": {
+                            "street": "address 1"
+                        }
+            }
+        }
+
+        assert self.request.input('key')['address']['street'] == 'address 1'
+        assert self.request.input('key.address.street') == 'address 1'
+        # assert self.request.input('key.') == False
+        # assert self.request.input('key.user') == '1'
+        # assert self.request.input('key.nothing') == False

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -631,6 +631,7 @@ class TestRequest:
 
         assert self.request.input('key')['address']['street'] == 'address 1'
         assert self.request.input('key.address.street') == 'address 1'
-        # assert self.request.input('key.') == False
-        # assert self.request.input('key.user') == '1'
-        # assert self.request.input('key.nothing') == False
+        assert self.request.input('key.') == False
+        assert self.request.input('key.user') == '1'
+        assert self.request.input('key.nothing') == False
+        assert self.request.input('key.nothing', default='test') == 'test'

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -607,3 +607,14 @@ class TestRequest:
         self.request.request_variables.update({'__token': 'testing', 'application': 'Masonite'})
         assert self.request.only('application') == {'application': 'Masonite'}
         assert self.request.only('__token') == {'__token': 'testing'}
+
+    def test_request_gets_only_clean_output(self):
+        self.request._set_standardized_request_variables({'key': '<img """><script>alert(\'hey\')</script>">'})
+        assert self.request.input('key') == '&lt;img &quot;&quot;&quot;&gt;&lt;script&gt;alert(&#x27;hey&#x27;)&lt;/script&gt;&quot;&gt;'
+        assert self.request.input('key', clean=False) == '<img """><script>alert(\'hey\')</script>">'
+    
+    def test_request_cleans_all_optionally(self):
+        self.request._set_standardized_request_variables({'key': '<img """><script>alert(\'hey\')</script>">'})
+        assert self.request.all()['key'] == '&lt;img &quot;&quot;&quot;&gt;&lt;script&gt;alert(&#x27;hey&#x27;)&lt;/script&gt;&quot;&gt;'
+        assert self.request.all(clean=False)['key'] == '<img """><script>alert(\'hey\')</script>">'
+


### PR DESCRIPTION
You may now specify whether the input you get should be cleaned or not. This change effects the `input` and `all` method:

```python
request.input('key', clean=False)
```

```python
request.all(clean=False)
```

will get the input uncleaned.

**This is a security risk though so use this with caution. Do not trust user input to be clean**

Closes #566 

****

This PR also closes #580 