### PR TITLE
Update and expand async queue driver

### DIFF
--- a/masonite/drivers/QueueAsyncDriver.py
+++ b/masonite/drivers/QueueAsyncDriver.py
@@ -10,6 +10,7 @@ from masonite.exceptions import QueueException
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import ProcessPoolExecutor
 
+
 class QueueAsyncDriver(BaseQueueDriver, QueueContract):
     """Queue Aysnc Driver."""
 
@@ -21,11 +22,10 @@ class QueueAsyncDriver(BaseQueueDriver, QueueContract):
         """
         self.container = app
 
-
     def _threading(self):
         """ Implements Async by Threading """
 
-        with ThreadPoolExecutor(max_workers = self.workers) as executor:
+        with ThreadPoolExecutor(max_workers=self.workers) as executor:
             for obj in self.objects:
                 if inspect.isclass(obj):
                     obj = self.container.resolve(obj)
@@ -40,7 +40,7 @@ class QueueAsyncDriver(BaseQueueDriver, QueueContract):
     def _multiprocessing(self):
         """ Implements Async by Multiprocesses """
 
-        with ProcessPoolExecutor(max_workers = self.workers) as executor:
+        with ProcessPoolExecutor(max_workers=self.workers) as executor:
             for obj in self.objects:
                 if inspect.isclass(obj):
                     obj = self.container.resolve(obj)

--- a/masonite/drivers/QueueAsyncDriver.py
+++ b/masonite/drivers/QueueAsyncDriver.py
@@ -2,6 +2,7 @@
 
 import inspect
 import threading
+import os
 
 from masonite.app import App
 from masonite.contracts import QueueContract
@@ -24,6 +25,14 @@ class QueueAsyncDriver(BaseQueueDriver, QueueContract):
 
     def _threading(self):
         """ Implements Async by Threading """
+
+        # Necessary for Python 3.4
+        if self.workers is None:
+            # Use this number because ThreadPoolExecutor is often
+            # used to overlap I/O instead of CPU work.
+            self.workers = (os.cpu_count() or 1) * 5
+        if self.workers <= 0:
+            raise QueueException("max_workers must be greater than 0")
 
         with ThreadPoolExecutor(max_workers=self.workers) as executor:
             for obj in self.objects:

--- a/masonite/drivers/QueueAsyncDriver.py
+++ b/masonite/drivers/QueueAsyncDriver.py
@@ -6,7 +6,9 @@ import threading
 from masonite.app import App
 from masonite.contracts import QueueContract
 from masonite.drivers import BaseQueueDriver
-
+from masonite.exceptions import QueueException
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 
 class QueueAsyncDriver(BaseQueueDriver, QueueContract):
     """Queue Aysnc Driver."""
@@ -19,22 +21,53 @@ class QueueAsyncDriver(BaseQueueDriver, QueueContract):
         """
         self.container = app
 
-    def push(self, *objects, args=(), callback='handle', ran=1, channel=None):
+
+    def _threading(self):
+        """ Implements Async by Threading """
+
+        with ThreadPoolExecutor(max_workers = self.workers) as executor:
+            for obj in self.objects:
+                if inspect.isclass(obj):
+                    obj = self.container.resolve(obj)
+
+                try:
+                    executor.submit(
+                        fn=getattr(obj, self.callback), args=self.args, kwargs=self.kwargs)
+                except AttributeError:
+                    # Could be wanting to call only a method asyncronously
+                    executor.submit(fn=obj, args=self.args, kwargs=self.kwargs)
+
+    def _multiprocessing(self):
+        """ Implements Async by Multiprocesses """
+
+        with ProcessPoolExecutor(max_workers = self.workers) as executor:
+            for obj in self.objects:
+                if inspect.isclass(obj):
+                    obj = self.container.resolve(obj)
+
+                try:
+                    executor.submit(
+                        fn=getattr(obj, self.callback), args=self.args, kwargs=self.kwargs)
+                except AttributeError:
+                    # Could be wanting to call only a method asyncronously
+                    executor.submit(fn=obj, args=self.args, kwargs=self.kwargs)
+
+    def push(self, *objects, args=(), kwargs={}, callback='handle', mode='threading', workers=None):
         """Push objects onto the async stack.
 
         Arguments:
             objects {*args of objects} - This can be several objects as parameters into this method.
         """
-        for obj in objects:
-            if inspect.isclass(obj):
-                obj = self.container.resolve(obj)
 
-            try:
-                thread = threading.Thread(
-                    target=getattr(obj, callback), args=args, kwargs={})
-            except AttributeError:
-                # Could be wanting to call only a method asyncronously
-                thread = threading.Thread(
-                    target=obj, args=args, kwargs={})
+        self.workers = workers
+        self.objects = objects
+        self.callback = callback
+        self.args = args
+        self.kwargs = kwargs
 
-            thread.start()
+        if mode == 'threading':
+            self._threading()
+        elif mode == 'multiprocess':
+            self._multiprocessing()
+        else:
+            raise QueueException('Queue mode {} not recognized'.format(mode))

--- a/masonite/exceptions.py
+++ b/masonite/exceptions.py
@@ -76,3 +76,6 @@ class DumpException(Exception):
 
 class ViewException(Exception):
     pass
+
+class QueueException(Exception):
+    pass

--- a/masonite/exceptions.py
+++ b/masonite/exceptions.py
@@ -77,5 +77,6 @@ class DumpException(Exception):
 class ViewException(Exception):
     pass
 
+
 class QueueException(Exception):
     pass

--- a/tests/queues/test_drivers.py
+++ b/tests/queues/test_drivers.py
@@ -2,9 +2,10 @@ from masonite.app import App
 from masonite.drivers import QueueAsyncDriver, QueueAmqpDriver
 from masonite.managers import QueueManager
 from config import queue
-
+from masonite.exceptions import QueueException
 from masonite.queues.Queueable import Queueable
 import os
+import pytest
 from masonite.environment import LoadEnvironment, env
 
 LoadEnvironment()
@@ -60,3 +61,13 @@ class TestAsyncDriver:
         assert isinstance(self.app.make('Queue'), QueueAsyncDriver)
         assert isinstance(self.app.make('Queue').driver('async'), QueueAsyncDriver)
         assert isinstance(self.app.make('Queue').driver('default'), QueueAsyncDriver)
+
+    def test_async_driver_with_threading(self):
+        assert self.app.make('QueueManager').driver('async').push(Job, mode='threading') is None
+
+    def test_async_driver_with_multiprocess(self):
+        assert self.app.make('QueueManager').driver('async').push(Job, mode='multiprocess') is None
+
+    def test_handle_unrecognized_mode(self):
+        with pytest.raises(QueueException, message="Should raise QueueException error"):
+            self.app.make('QueueManager').driver('async').push(Job, mode='blah')

--- a/tests/queues/test_drivers.py
+++ b/tests/queues/test_drivers.py
@@ -71,3 +71,7 @@ class TestAsyncDriver:
     def test_handle_unrecognized_mode(self):
         with pytest.raises(QueueException, message="Should raise QueueException error"):
             self.app.make('QueueManager').driver('async').push(Job, mode='blah')
+
+    def test_async_driver_specify_workers(self):
+        assert self.app.make('QueueManager').driver('async').push(Job, mode='threading', workers=2) is None
+        assert self.app.make('QueueManager').driver('async').push(Job, mode='multiprocess', workers=2) is None

--- a/tests/queues/test_drivers.py
+++ b/tests/queues/test_drivers.py
@@ -75,3 +75,7 @@ class TestAsyncDriver:
     def test_async_driver_specify_workers(self):
         assert self.app.make('QueueManager').driver('async').push(Job, mode='threading', workers=2) is None
         assert self.app.make('QueueManager').driver('async').push(Job, mode='multiprocess', workers=2) is None
+
+    def test_threading_workers_are_nonnegative(self):
+        with pytest.raises(QueueException, message="Should raise QueueException error"):
+            self.app.make('QueueManager').driver('async').push(Job, mode='threading', workers=-1)


### PR DESCRIPTION
Have option to use threading or multiprocessing. Also uses `concurrent.futures` for a consistent api between threading and multiprocessing. Also allows the user to specify the amount of threads/processes they want to use.