### PR TITLE
Add view shortcut

### DIFF
--- a/app/http/controllers/TestController.py
+++ b/app/http/controllers/TestController.py
@@ -4,6 +4,7 @@ from masonite.exceptions import DebugException
 from masonite.request import Request
 from masonite import Queue
 from app.jobs.TestJob import TestJob
+from masonite.view import View
 
 
 class TestController:
@@ -22,10 +23,13 @@ class TestController:
         request.status(203)
         return 'test'
 
-    def testing(self):
-        return 'test'
+    def view(self, view: View):
+        return view.render('test', {'test': 'test'}) & 203
 
-    def json_response(self):
+    def testing(self):
+        return 'testering'
+
+    def json_response(self, view: View):
         return {'id': 1}
 
     def post_test(self):

--- a/masonite/view.py
+++ b/masonite/view.py
@@ -304,3 +304,11 @@ class View:
     def set_splice(self, splice):
         self._splice = splice
         return self
+
+    def __and__(self, status):
+        from wsgi import container
+        from masonite.request import Request
+        
+        request = container.make(Request)
+        request.status(status)
+        return self

--- a/masonite/view.py
+++ b/masonite/view.py
@@ -306,9 +306,8 @@ class View:
         return self
 
     def __and__(self, status):
-        from wsgi import container
         from masonite.request import Request
 
-        request = container.make(Request)
+        request = self.container.make(Request)
         request.status(status)
         return self

--- a/masonite/view.py
+++ b/masonite/view.py
@@ -308,7 +308,7 @@ class View:
     def __and__(self, status):
         from wsgi import container
         from masonite.request import Request
-        
+
         request = container.make(Request)
         request.status(status)
         return self

--- a/routes/web.py
+++ b/routes/web.py
@@ -7,6 +7,7 @@ ROUTES = [
     Get().route('/test', None).middleware('auth'),
     Get().route('/queue', 'TestController@queue'),
     Redirect('/redirect', 'test'),
+    Get().route('/test/view', 'TestController@view'),
     Get().domain('test').route('/test', None).middleware('auth'),
     Get().domain('test').route('/unit/test', 'TestController@testing').middleware('auth'),
     Get().domain('test').route('/test/route', 'TestController@testing'),

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -10,6 +10,8 @@ from masonite.drivers.CacheDiskDriver import CacheDiskDriver
 from masonite.exceptions import RequiredContainerBindingNotFound, ViewException
 from masonite.managers.CacheManager import CacheManager
 from masonite.view import View
+from masonite.request import Request
+from masonite.testsuite import generate_wsgi
 
 
 class TestView:
@@ -17,6 +19,7 @@ class TestView:
     def setup_method(self):
         self.container = App()
         view = View(self.container)
+        self.container.bind('Request', Request(generate_wsgi()).load_app(self.container))
 
         self.container.bind('View', view.render)
         self.container.bind('ViewClass', view)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -272,6 +272,9 @@ class TestView:
         assert view.render(
             'admin_test', {'user': user}).rendered_template == 'False'
 
+    def test_uses_and_logic_operator(self):
+        assert self.container.make('ViewClass') & 200
+
     def _is_admin(self, obj):
         return obj.admin == 1
 


### PR DESCRIPTION
Closes #592 

This PR allows you to set a status codes easier. You can now do something like this when returning a view.

we currently do something like this:

```python
def show(self, view: View, request: Request):
    request.status(203)
    return view.render('some.view', {'key': 'value'})
```

now you can do:

```python
def show(self, view: View):
    return view.render('some.view', {'key': 'value'}) & 203
```

the `&` is a shortcut is still experimental and could change. Any suggestions are welcome.