### PR TITLE
added compact helper

### DIFF
--- a/masonite/exceptions.py
+++ b/masonite/exceptions.py
@@ -77,5 +77,6 @@ class DumpException(Exception):
 class ViewException(Exception):
     pass
 
+
 class AmbiguousError(Exception):
     pass

--- a/masonite/exceptions.py
+++ b/masonite/exceptions.py
@@ -76,3 +76,6 @@ class DumpException(Exception):
 
 class ViewException(Exception):
     pass
+
+class AmbiguousError(Exception):
+    pass

--- a/masonite/helpers/__init__.py
+++ b/masonite/helpers/__init__.py
@@ -1,7 +1,7 @@
 from .static import static
 from .password import password
 from .validator import validate
-from .misc import random_string, dot, clean_request_input, HasColoredCommands, compact
+from .misc import random_string, dot, clean_request_input, HasColoredCommands, Compact as compact
 from .Extendable import Extendable
 from .time import cookie_expire_time
 from .structures import config, Dot

--- a/masonite/helpers/__init__.py
+++ b/masonite/helpers/__init__.py
@@ -1,7 +1,7 @@
 from .static import static
 from .password import password
 from .validator import validate
-from .misc import random_string, dot, clean_request_input, HasColoredCommands
+from .misc import random_string, dot, clean_request_input, HasColoredCommands, compact
 from .Extendable import Extendable
 from .time import cookie_expire_time
 from .structures import config, Dot

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -84,7 +84,8 @@ class Compact():
             for key, value in frame.f_back.f_locals.items():
                 if value == arg:
                     self.dictionary.update({key: value})
+                    break
 
         if len(args) != len(self.dictionary):
-            raise ValueError('Could not find all variables in this namespace')
+            raise ValueError('Could not find all variables in this')
         return self.dictionary

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -2,6 +2,7 @@
 
 import random
 import string
+from masonite.exceptions import AmbiguousError
 
 
 def random_string(length=4):
@@ -81,10 +82,13 @@ class Compact():
                 self.dictionary.update(arg)
                 continue
 
+            found = []
             for key, value in frame.f_back.f_locals.items():
                 if value == arg:
+                    if value in found:
+                        raise AmbiguousError('Cannot contain variables with multiple of the same object in scope')
                     self.dictionary.update({key: value})
-                    break
+                    found.append(value)
 
         if len(args) != len(self.dictionary):
             raise ValueError('Could not find all variables in this')

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -85,4 +85,6 @@ class Compact():
                 if value == arg:
                     self.dictionary.update({key: value})
 
+        if len(args) != len(self.dictionary):
+            raise ValueError('Could not find all variables in this namespace')
         return self.dictionary

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -73,16 +73,16 @@ class Compact():
     def __new__(self, *args):
         import inspect
         frame = inspect.currentframe()
+
         self.dictionary = {}
         for arg in args:
+
             if isinstance(arg, dict):
                 self.dictionary.update(arg)
                 continue
-            try:
-                self.dictionary.update({
-                    arg: frame.f_back.f_locals[arg]
-                })
-            except KeyError:
-                raise KeyError('{} is not in the current namespace'.format(arg))
+
+            for key, value in frame.f_back.f_locals.items():
+                if value == arg:
+                    self.dictionary.update({key: value})
 
         return self.dictionary

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -85,8 +85,11 @@ class Compact():
             found = []
             for key, value in frame.f_back.f_locals.items():
                 if value == arg:
-                    if value in found:
-                        raise AmbiguousError('Cannot contain variables with multiple of the same object in scope')
+                    for f in found:
+                        if value is f:
+                            raise AmbiguousError(
+                                'Cannot contain variables with multiple of the same object in scope. '
+                                'Getting {}'.format(value))
                     self.dictionary.update({key: value})
                     found.append(value)
 

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -68,16 +68,21 @@ class HasColoredCommands:
         print('\033[91m {0} \033[0m'.format(message))
 
 
-def compact(*args):
-    import inspect
-    frame = inspect.currentframe()
-    dictionary = {}
-    for arg in args:
-        try:
-            dictionary.update({
-                arg: frame.f_back.f_locals[arg]
-            })
-        except KeyError:
-            raise KeyError('{} is not in the current namespace'.format(arg))
+class Compact():
 
-    return dictionary
+    def __new__(self, *args):
+        import inspect
+        frame = inspect.currentframe()
+        self.dictionary = {}
+        for arg in args:
+            if isinstance(arg, dict):
+                self.dictionary.update(arg)
+                continue
+            try:
+                self.dictionary.update({
+                    arg: frame.f_back.f_locals[arg]
+                })
+            except KeyError:
+                raise KeyError('{} is not in the current namespace'.format(arg))
+
+        return self.dictionary

--- a/masonite/helpers/misc.py
+++ b/masonite/helpers/misc.py
@@ -66,3 +66,18 @@ class HasColoredCommands:
 
     def danger(self, message):
         print('\033[91m {0} \033[0m'.format(message))
+
+
+def compact(*args):
+    import inspect
+    frame = inspect.currentframe()
+    dictionary = {}
+    for arg in args:
+        try:
+            dictionary.update({
+                arg: frame.f_back.f_locals[arg]
+            })
+        except KeyError:
+            raise KeyError('{} is not in the current namespace'.format(arg))
+
+    return dictionary

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -27,4 +27,4 @@ class TestCompact:
     def test_compact_works_with_classes(self):
         r = Request(None)
         request = r
-        assert compact(request) == {'request': r}
+        assert 'request' in compact(request)

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -1,6 +1,7 @@
 from masonite.helpers import compact
 import pytest
 from masonite.request import Request
+from masonite.exceptions import AmbiguousError
 
 class TestCompact:
 
@@ -24,7 +25,12 @@ class TestCompact:
         with pytest.raises(ValueError):
             compact(x, y, 'z')
 
-    def test_compact_works_with_classes(self):
+    def test_compact_throws_exceptions(self):
         r = Request(None)
         request = r
-        assert 'request' in compact(request)
+        with pytest.raises(AmbiguousError):
+            compact(request)
+
+    def test_works_with_classes(self):
+        request = Request(None)
+        assert 'request' in compact(request) 

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -4,14 +4,14 @@ class TestCompact:
 
     def test_compact_returns_dict_of_local_variable(self):
         x = 'hello'
-        assert compact('x') == {'x': 'hello'}
+        assert compact(x) == {'x': 'hello'}
     
     def test_works_with_several_variables(self):
         x = 'hello'
         y = 'world'
-        assert compact('x', 'y') == {'x': 'hello', 'y': 'world'}
+        assert compact(x, y) == {'x': 'hello', 'y': 'world'}
     
     def test_can_contain_dict(self):
         x = 'hello'
         y = 'world'
-        assert compact('x', 'y', {'z': 'foo'}) == {'x': 'hello', 'y': 'world', 'z': 'foo'}
+        assert compact(x, y, {'z': 'foo'}) == {'x': 'hello', 'y': 'world', 'z': 'foo'}

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -1,5 +1,5 @@
 from masonite.helpers import compact
-
+import pytest
 class TestCompact:
 
     def test_compact_returns_dict_of_local_variable(self):
@@ -15,3 +15,9 @@ class TestCompact:
         x = 'hello'
         y = 'world'
         assert compact(x, y, {'z': 'foo'}) == {'x': 'hello', 'y': 'world', 'z': 'foo'}
+
+    def test_exception_on_too_many(self):
+        x = 'hello'
+        y = 'world'
+        with pytest.raises(ValueError):
+            compact(x, y, 'z')

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -1,5 +1,7 @@
 from masonite.helpers import compact
 import pytest
+from masonite.request import Request
+
 class TestCompact:
 
     def test_compact_returns_dict_of_local_variable(self):
@@ -21,3 +23,8 @@ class TestCompact:
         y = 'world'
         with pytest.raises(ValueError):
             compact(x, y, 'z')
+
+    def test_compact_works_with_classes(self):
+        r = Request(None)
+        request = r
+        assert compact(request) == {'request': r}

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -10,3 +10,8 @@ class TestCompact:
         x = 'hello'
         y = 'world'
         assert compact('x', 'y') == {'x': 'hello', 'y': 'world'}
+    
+    def test_can_contain_dict(self):
+        x = 'hello'
+        y = 'world'
+        assert compact('x', 'y', {'z': 'foo'}) == {'x': 'hello', 'y': 'world', 'z': 'foo'}

--- a/tests/helpers/test_compact.py
+++ b/tests/helpers/test_compact.py
@@ -1,0 +1,12 @@
+from masonite.helpers import compact
+
+class TestCompact:
+
+    def test_compact_returns_dict_of_local_variable(self):
+        x = 'hello'
+        assert compact('x') == {'x': 'hello'}
+    
+    def test_works_with_several_variables(self):
+        x = 'hello'
+        y = 'world'
+        assert compact('x', 'y') == {'x': 'hello', 'y': 'world'}


### PR DESCRIPTION
it is very repetitive when you want to have a variable name and you want to send a variable to the view with the same name. This may look something like this:

```python
def show(self, view: View):
    posts = Post.all()
    users = User.all()
    return view.render('some.template', {'posts': posts, 'users': users})
```

now you can do:

```python
from masonite.helpers import compact

def show(self, view: View):
    posts = Post.all()
    users = User.all()
    return view.render('some.template', compact(posts, users))
```

You can also pass in a dictionary which will update accordingly:

```python
from masonite.helpers import compact

def show(self, view: View):
    posts = Post.all()
    users = User.all()
    user_blogs = Blog.where('user_id', 1).get()
    return view.render('some.template', compact(posts, users, {'blogs': user_blogs}))
```