### PR TITLE
Feature: Add more http verbs

### DIFF
--- a/masonite/drivers/storage/StorageDiskDriver.py
+++ b/masonite/drivers/storage/StorageDiskDriver.py
@@ -5,7 +5,6 @@ import shutil
 from masonite import Upload
 from masonite.contracts import StorageContract
 from masonite.drivers import BaseDriver
-from masonite.helpers.filesystem import make_directory
 
 
 class StorageDiskDriver(BaseDriver, StorageContract):
@@ -51,7 +50,8 @@ class StorageDiskDriver(BaseDriver, StorageContract):
         from wsgi import container
         return container.make(Upload).driver('disk').store(*args, **kwargs)
 
-    def all(self): pass
+    def all(self): 
+        pass
 
     def make_directory(self, location):
         location = os.path.join(os.getcwd(), location)

--- a/masonite/drivers/storage/StorageDiskDriver.py
+++ b/masonite/drivers/storage/StorageDiskDriver.py
@@ -50,7 +50,7 @@ class StorageDiskDriver(BaseDriver, StorageContract):
         from wsgi import container
         return container.make(Upload).driver('disk').store(*args, **kwargs)
 
-    def all(self): 
+    def all(self):
         pass
 
     def make_directory(self, location):

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -388,10 +388,10 @@ class Post(BaseHttpRoute):
 
 
 class Match(BaseHttpRoute):
-    """Class for specifying POST requests."""
+    """Class for specifying Match requests."""
 
     def __init__(self, method_type=['GET'], route=None, output=None):
-        """Post constructor."""
+        """Match constructor."""
         if not isinstance(method_type, list):
             raise RouteException("Method type needs to be a list. Got '{}'".format(method_type))
 

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -376,6 +376,17 @@ class Get(BaseHttpRoute):
             self.route(route, output)
 
 
+class Head(BaseHttpRoute):
+    """Class for specifying HEAD requests."""
+
+    def __init__(self, route=None, output=None):
+        """Head constructor."""
+        self.method_type = ['HEAD']
+        self.list_middleware = []
+        if route and output:
+            self.route(route, output)
+
+
 class Post(BaseHttpRoute):
     """Class for specifying POST requests."""
 
@@ -430,6 +441,39 @@ class Delete(BaseHttpRoute):
     def __init__(self, route=None, output=None):
         """Delete constructor."""
         self.method_type = ['DELETE']
+        self.list_middleware = []
+        if route and output:
+            self.route(route, output)
+
+
+class Connect(BaseHttpRoute):
+    """Class for specifying Connect requests."""
+
+    def __init__(self, route=None, output=None):
+        """Connect constructor."""
+        self.method_type = ['CONNECT']
+        self.list_middleware = []
+        if route and output:
+            self.route(route, output)
+
+
+class Options(BaseHttpRoute):
+    """Class for specifying GET requests."""
+
+    def __init__(self, route=None, output=None):
+        """Options constructor."""
+        self.method_type = ['OPTIONS']
+        self.list_middleware = []
+        if route and output:
+            self.route(route, output)
+
+
+class Trace(BaseHttpRoute):
+    """Class for specifying Trace requests."""
+
+    def __init__(self, route=None, output=None):
+        """Trace constructor."""
+        self.method_type = ['TRACE']
         self.list_middleware = []
         if route and output:
             self.route(route, output)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,7 @@
 from masonite.routes import Route
 from masonite.request import Request
 from masonite.app import App
-from masonite.routes import Get, Post, Put, Patch, Delete, RouteGroup, Match, Redirect
+from masonite.routes import Get, Head, Post, Match, Put, Patch, Delete, Connect, Options, Trace, RouteGroup, Redirect
 from masonite.helpers.routes import group, flatten_routes
 from masonite.testsuite.TestSuite import generate_wsgi
 from masonite.exceptions import InvalidRouteCompileException, RouteException

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -17,10 +17,15 @@ class TestRoutes:
 
     def test_route_is_callable(self):
         assert callable(Get)
+        assert callable(Head)
         assert callable(Post)
+        assert callable(Match)
         assert callable(Put)
         assert callable(Patch)
         assert callable(Delete)
+        assert callable(Connect)
+        assert callable(Options)
+        assert callable(Trace)
 
     def test_route_get_returns_output(self):
         assert self.route.get('url', 'output') == 'output'
@@ -72,6 +77,8 @@ class TestRoutes:
     def test_route_can_pass_route_values_in_constructor(self):
         route = Get('test/url', 'BreakController@show')
         assert route.route_url == '/test/url'
+        route = Head('test/url', 'BreakController@show')
+        assert route.route_url == '/test/url'
         route = Post('test/url', 'BreakController@show')
         assert route.route_url == '/test/url'
         route = Put('test/url', 'BreakController@show')
@@ -79,6 +86,12 @@ class TestRoutes:
         route = Patch('test/url', 'BreakController@show')
         assert route.route_url == '/test/url'
         route = Delete('test/url', 'BreakController@show')
+        assert route.route_url == '/test/url'
+        route = Connect('test/url', 'BreakController@show')
+        assert route.route_url == '/test/url'
+        route = Options('test/url', 'BreakController@show')
+        assert route.route_url == '/test/url'
+        route = Trace('test/url', 'BreakController@show')
         assert route.route_url == '/test/url'
 
     def test_route_can_pass_route_values_in_constructor_and_use_middleware(self):
@@ -209,7 +222,7 @@ class TestRoutes:
         assert route.environ['QUERY_STRING'] == {
             "options": ["foo", "bar"]
         }
-    
+
     def test_redirect_route(self):
         route = Redirect('/test1', '/test2')
         request = Request(generate_wsgi())
@@ -223,7 +236,7 @@ class TestRoutes:
     def test_redirect_can_use_301(self):
         request = Request(generate_wsgi())
         route = Redirect('/test1', '/test3', status=301)
-        
+
         route.load_request(request)
         request.load_app(App())
         route.get_response()


### PR DESCRIPTION
Closes #623. 

Add more http verbs for our routes. These are according to [Mozilla Developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).

We should now be up to date with today's specifications.