### PR TITLE
Feature/json 404 and 500 response

### DIFF
--- a/masonite/providers/StatusCodeProvider.py
+++ b/masonite/providers/StatusCodeProvider.py
@@ -35,12 +35,16 @@ class StatusCodeProvider(ServiceProvider):
             return
 
         if request.get_status() in (500, 405, 404):
-            if self.app.make('ViewClass').exists('errors/{}'.format(request.get_status())):
-                rendered_view = self.app.make('View')(
-                    'errors/{}'.format(request.get_status()))
+            if request.header('Content-Type') == 'application/json':
+                json_response = {'error': {'status': request.get_status()}}
+                response.view(json_response, status=request.get_status())
             else:
-                rendered_view = self.app.make('View')('/masonite/snippets/statuscode', {
-                    'code': request.get_status_code()
-                })
+                if self.app.make('ViewClass').exists('errors/{}'.format(request.get_status())):
+                    rendered_view = self.app.make('View')(
+                        'errors/{}'.format(request.get_status()))
+                else:
+                    rendered_view = self.app.make('View')('/masonite/snippets/statuscode', {
+                        'code': request.get_status_code()
+                    })
 
-            response.view(rendered_view, status=request.get_status())
+                response.view(rendered_view, status=request.get_status())

--- a/masonite/providers/StatusCodeProvider.py
+++ b/masonite/providers/StatusCodeProvider.py
@@ -36,9 +36,11 @@ class StatusCodeProvider(ServiceProvider):
 
         if request.get_status() in (500, 405, 404):
             if request.header('Content-Type') == 'application/json':
+                # Returns json response when we want the client to receive a json response
                 json_response = {'error': {'status': request.get_status()}}
                 response.view(json_response, status=request.get_status())
             else:
+                # Returns html response when json is not explicitly specified
                 if self.app.make('ViewClass').exists('errors/{}'.format(request.get_status())):
                     rendered_view = self.app.make('View')(
                         'errors/{}'.format(request.get_status()))


### PR DESCRIPTION
Closes Issue #622.

Allows one to specify either to return a json response or html response for 404, 405, and 500 status codes.