### PR TITLE
exception thrown when a route name does not exist

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -715,10 +715,10 @@ class Request(Extendable):
             route = application.URL + self._get_named_route(name, params)
         else:
             route = self._get_named_route(name, params)
-        
+
         if not route:
             raise RouteException("Route with the name of '{}' was not found.".format(name))
-        
+
         return route
 
     def reset_redirections(self):

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -18,7 +18,7 @@ from cryptography.fernet import InvalidToken
 
 from config import application
 from masonite.auth.Sign import Sign
-from masonite.exceptions import InvalidHTTPStatusCode
+from masonite.exceptions import InvalidHTTPStatusCode, RouteException
 from masonite.helpers import dot, clean_request_input, Dot as DictDot
 from masonite.helpers.Extendable import Extendable
 from masonite.helpers.routes import compile_route_to_regex
@@ -712,9 +712,14 @@ class Request(Extendable):
             masonite.routes.Route|None -- Returns None if the route cannot be found.
         """
         if full:
-            return application.URL + self._get_named_route(name, params)
-
-        return self._get_named_route(name, params)
+            route = application.URL + self._get_named_route(name, params)
+        else:
+            route = self._get_named_route(name, params)
+        
+        if not route:
+            raise RouteException("Route with the name of '{}' was not found.".format(name))
+        
+        return route
 
     def reset_redirections(self):
         """Reset the redirections because of this class acting like a singleton pattern."""

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -8,7 +8,7 @@ from cgi import MiniFieldStorage
 from masonite.request import Request
 from masonite.response import Response
 from masonite.app import App
-from masonite.exceptions import InvalidHTTPStatusCode
+from masonite.exceptions import InvalidHTTPStatusCode, RouteException
 from masonite.routes import Get, Route
 from masonite.helpers.routes import flatten_routes, get, group
 from masonite.helpers.time import cookie_expire_time
@@ -264,6 +264,9 @@ class TestRequest:
         assert request.route('test.url') == '/test/url'
         assert request.route('test.id', {'id': 1}) == '/test/url/1'
         assert request.route('test.id', [1]) == '/test/url/1'
+
+        with pytest.raises(RouteException):
+            assert request.route('not.exists', [1])
 
     def test_request_redirection(self):
         app = App()


### PR DESCRIPTION
This PR now throws an exception when a route name was not found.