### PR TITLE
Feature 645

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,5 +1,5 @@
 """ Middleware Configuration Settings """
-from masonite.middleware import ResponseMiddleware, SecureHeadersMiddleware, CorsMiddleware
+from masonite.middleware import ResponseMiddleware, SecureHeadersMiddleware, CorsMiddleware, MaintenanceModeMiddleware
 
 from app.http.middleware.AddAttributeMiddleware import AddAttributeMiddleware
 from app.http.middleware.AuthenticationMiddleware import \

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -724,7 +724,6 @@ class Request(Extendable):
         return route
 
     def __getattr__(self, key):
-        print('getting', key)
         inp = self.input(key)
         if inp:
             return inp

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -718,6 +718,18 @@ class Request(Extendable):
 
         return self._get_named_route(name, params)
 
+    def __getattr__(self, key):
+        print('getting', key)
+        inp = self.input(key)
+        if inp:
+            return inp
+
+        inp = self.param(key)
+        if inp:
+            return inp
+
+        raise ValueError('No input or parameter of {} found'.format(key))
+
     def reset_redirections(self):
         """Reset the redirections because of this class acting like a singleton pattern."""
         self.redirect_url = False

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -8,7 +8,7 @@ from cgi import MiniFieldStorage
 from masonite.request import Request
 from masonite.response import Response
 from masonite.app import App
-from masonite.exceptions import InvalidHTTPStatusCode
+from masonite.exceptions import InvalidHTTPStatusCode, RouteException
 from masonite.routes import Get, Route
 from masonite.helpers.routes import flatten_routes, get, group
 from masonite.helpers.time import cookie_expire_time
@@ -264,6 +264,9 @@ class TestRequest:
         assert request.route('test.url') == '/test/url'
         assert request.route('test.id', {'id': 1}) == '/test/url/1'
         assert request.route('test.id', [1]) == '/test/url/1'
+
+        with pytest.raises(RouteException):
+            assert request.route('not.exists', [1])
 
     def test_request_redirection(self):
         app = App()
@@ -590,6 +593,16 @@ class TestRequest:
     def test_contains_multiple_asteriks(self):
         self.request.path = '/dashboard/user/edit/1'
         assert self.request.contains('/dashboard/user/*:string/*:int')
+
+    def test_request_can_get_input_as_properties(self):
+        self.request.request_variables = {'test': 'hey'}
+        assert self.request.test == 'hey'
+        assert self.request.input('test') == 'hey'
+
+    def test_request_can_get_param_as_properties(self):
+        self.request.url_params = {'test': 'hey'}
+        assert self.request.test == 'hey'
+        assert self.request.param('test') == 'hey'
 
     def test_back_returns_correct_url(self):
         self.request.path = '/dashboard/create'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -42,26 +42,26 @@ class TestRoutes:
 
     def test_compile_route_to_regex(self):
         get_route = Get().route('test/route', None)
-        assert get_route.compile_route_to_regex(self.route) == r'^test\/route\/$'
+        assert get_route.compile_route_to_regex(self.route) == r'^\/test\/route\/$'
 
         get_route = Get().route('test/@route', None)
-        assert get_route.compile_route_to_regex(self.route) == r'^test\/([\w.-]+)\/$'
+        assert get_route.compile_route_to_regex(self.route) == r'^\/test\/([\w.-]+)\/$'
 
         get_route = Get().route('test/@route:int', None)
-        assert get_route.compile_route_to_regex(self.route) == r'^test\/(\d+)\/$'
+        assert get_route.compile_route_to_regex(self.route) == r'^\/test\/(\d+)\/$'
 
         get_route = Get().route('test/@route:string', None)
-        assert get_route.compile_route_to_regex(self.route) == r'^test\/([a-zA-Z]+)\/$'
+        assert get_route.compile_route_to_regex(self.route) == r'^\/test\/([a-zA-Z]+)\/$'
 
     def test_route_can_add_compilers(self):
         get_route = Get().route('test/@route:int', None)
-        assert get_route.compile_route_to_regex(self.route) == r'^test\/(\d+)\/$'
+        assert get_route.compile_route_to_regex(self.route) == r'^\/test\/(\d+)\/$'
 
         self.route.compile('year', r'[0-9]{4}')
 
         get_route = Get().route('test/@route:year', None)
 
-        assert get_route.compile_route_to_regex(self.route) == r'^test\/[0-9]{4}\/$'
+        assert get_route.compile_route_to_regex(self.route) == r'^\/test\/[0-9]{4}\/$'
 
         get_route = Get().route('test/@route:slug', None)
         with pytest.raises(InvalidRouteCompileException):


### PR DESCRIPTION
Closes #645 

This PR allows you to get input and params by directly accessing the request class.

This can be used like so:

```
#== route: /dashboard/@id
def show(self, request: Request):
    user = User.find(request.id)
```

Instead of:

```python
#== route: /dashboard/@id
def show(self, request: Request):
    user = User.find(request.param('id'))
```

This can also be used for inputs as well:

```python
#== route: /dashboard/5?active=1
def show(self, request: Request):
    user = User.find(request.id) #== request.id = 5
    user = request.active #== request.active = 1
    user.save()
```

Notice how it is using both the param and the input list. Input is the first lookup followed by the params