### PR TITLE
added line statements

### DIFF
--- a/masonite/view.py
+++ b/masonite/view.py
@@ -237,7 +237,8 @@ class View:
             self.env = Environment(
                 loader=loader,
                 autoescape=select_autoescape(['html', 'xml']),
-                extensions=self._jinja_extensions
+                extensions=self._jinja_extensions,
+                line_statement_prefix='@'
             )
 
         else:
@@ -253,7 +254,8 @@ class View:
             self.env = Environment(
                 loader=loader,
                 autoescape=select_autoescape(['html', 'xml']),
-                extensions=self._jinja_extensions
+                extensions=self._jinja_extensions,
+                line_statement_prefix='@'
             )
 
         self.env.filters.update(self._filters)

--- a/resources/templates/line-statements.html
+++ b/resources/templates/line-statements.html
@@ -1,0 +1,3 @@
+@if test:
+    {{ test }}
+@endif

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -292,6 +292,10 @@ class TestView:
         view = self.container.make('ViewClass')
         assert view.render('mail.share', {'test': 'test'}).rendered_template == 'test'
 
+    def test_can_use_at_line_statements(self):
+        view = self.container.make('ViewClass')
+        assert 'test this string' in view.render('line-statements', {'test': 'test this string'}).rendered_template
+
 
 class MockAdminUser:
     admin = 1


### PR DESCRIPTION
Not sure why it took so long to do this but I added jinja2 line statements. Instead of writing templates like this:

```html
{% extends 'base/nav.html' %}

{% block content %}

{% if some_variable %}
    {{ variable }}
{% endif %}

{% endblock %}
```

we can now do:

```html
@extends 'base/nav.html'

@block content
    @if some_variable:
        {{ variable }}
    @endif
@endblock
```