### PR TITLE
Fix/686 - Contains Method

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -811,7 +811,7 @@ class Request(Extendable):
         if show is not None:
             if re.match(compile_route_to_regex(route), self.path):
                 return show
-            
+
             return ''
 
         return re.match(compile_route_to_regex(route), self.path)

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -799,7 +799,7 @@ class Request(Extendable):
 
         return False
 
-    def contains(self, route):
+    def contains(self, route, show=None):
         """If the specified URI is in the current URI path.
 
         Arguments:
@@ -808,6 +808,9 @@ class Request(Extendable):
         Returns:
             bool
         """
+        if show is not None:
+            if re.match(compile_route_to_regex(route), self.path):
+                return show
         return re.match(compile_route_to_regex(route), self.path)
 
     def compile_route_to_url(self, route, params={}):

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -808,9 +808,12 @@ class Request(Extendable):
         Returns:
             bool
         """
-        if show is not None and re.match(compile_route_to_regex(route), self.path):
-            return show
+        if show is not None:
+            if re.match(compile_route_to_regex(route), self.path):
+                return show
             
+            return ''
+
         return re.match(compile_route_to_regex(route), self.path)
 
     def compile_route_to_url(self, route, params={}):

--- a/masonite/request.py
+++ b/masonite/request.py
@@ -808,9 +808,9 @@ class Request(Extendable):
         Returns:
             bool
         """
-        if show is not None:
-            if re.match(compile_route_to_regex(route), self.path):
-                return show
+        if show is not None and re.match(compile_route_to_regex(route), self.path):
+            return show
+            
         return re.match(compile_route_to_regex(route), self.path)
 
     def compile_route_to_url(self, route, params={}):

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -585,6 +585,7 @@ class TestRequest(unittest.TestCase):
     def test_contains_can_return_string(self):
         self.request.path = '/test/path/5'
         self.assertEqual(self.request.contains('/test/*', show='active'), 'active')
+        self.assertEqual(self.request.contains('/test/not', show='active'), '')
 
     def test_contains_for_path_with_digit(self):
         self.request.path = '/test/path/1'

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -96,7 +96,7 @@ class TestRequest(unittest.TestCase):
 
         self.assertEqual(self.request.get_cookie('delete_cookie'), 'value')
         self.request.delete_cookie('delete_cookie')
-        assert not self.request.get_cookie('delete_cookie')
+        self.assertFalse(self.request.get_cookie('delete_cookie'))
 
     def test_delete_cookie_with_wrong_key(self):
         self.request.cookies = []
@@ -411,7 +411,7 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(request.header('HTTP_UPGRADE_INSECURE_REQUESTS'), '1')
         self.assertEqual(request.header('RAW_URI'), '/')
         self.assertEqual(request.header('NOT_IN'), '')
-        assert not 'text/html' in request.header('NOT_IN')
+        self.assertFalse('text/html' in request.header('NOT_IN'))
 
     def test_request_sets_correct_header(self):
         app = App()
@@ -574,34 +574,38 @@ class TestRequest(unittest.TestCase):
 
     def test_contains_for_path_detection(self):
         self.request.path = '/test/path'
-        assert self.request.contains('/test/*')
-        assert self.request.contains('/test/path')
-        assert not self.request.contains('/test/wrong')
+        self.assertTrue(self.request.contains('/test/*'))
+        self.assertTrue(self.request.contains('/test/path'))
+        self.assertFalse(self.request.contains('/test/wrong'))
 
     def test_contains_for_multiple_paths(self):
         self.request.path = '/test/path/5'
-        assert self.request.contains('/test/*')
+        self.assertTrue(self.request.contains('/test/*'))
+
+    def test_contains_can_return_string(self):
+        self.request.path = '/test/path/5'
+        self.assertEqual(self.request.contains('/test/*', show='active'), 'active')
 
     def test_contains_for_path_with_digit(self):
         self.request.path = '/test/path/1'
-        assert self.request.contains('/test/path/*')
-        assert self.request.contains('/test/path/*:int')
+        self.assertTrue(self.request.contains('/test/path/*'))
+        self.assertTrue(self.request.contains('/test/path/*:int'))
 
     def test_contains_for_path_with_digit_and_wrong_contains(self):
         self.request.path = '/test/path/joe'
-        assert not self.request.contains('/test/path/*:int')
+        self.assertFalse(self.request.contains('/test/path/*:int'))
 
     def test_contains_for_path_with_alpha_contains(self):
         self.request.path = '/test/path/joe'
-        assert self.request.contains('/test/path/*:string')
+        self.assertTrue(self.request.contains('/test/path/*:string'))
 
     def test_contains_for_route_compilers(self):
         self.request.path = '/test/path/joe'
-        assert self.request.contains('/test/path/*:signed')
+        self.assertTrue(self.request.contains('/test/path/*:signed'))
 
     def test_contains_multiple_asteriks(self):
         self.request.path = '/dashboard/user/edit/1'
-        assert self.request.contains('/dashboard/user/*:string/*:int')
+        self.assertTrue(self.request.contains('/dashboard/user/*:string/*:int'))
 
     def test_request_can_get_input_as_properties(self):
         self.request.request_variables = {'test': 'hey'}


### PR DESCRIPTION
This PR adds a `show` parameter to the contains method so now we can do something like this:

```html
<a href=".." class="{{ contains('/dashboard/*', show='active') }}">Dashboard</a>
```

instead of what we had before:

```html
<a href=".." class="{% if contains('/dashboard/*') %} active {% endif %}">Dashboard</a>
```