### PR TITLE
Feature/781 Add assertDatabaseHas

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ The versions below are the currently supported bug fixes and security fixes.
 | Version   | Bug Fixes            | Security Fixes        | End Of Life        |
 | --------- | -------------------- | ----------------------|------------------- |
 | 2.2.x LTS | :white_check_mark:   | :white_check_mark:    | June 2022
-| 2.1.x     | :white_check_mark:   | :white_check_mark:    | June 2019
+| 2.1.x     | :x:                  | :x:                   | June 2019
 | 2.0.x     | :x:                  | :x:                   | December 2018
 | 1.6.x     | :x:                  | :x:                   | June 2018
 

--- a/masonite/testing/TestCase.py
+++ b/masonite/testing/TestCase.py
@@ -199,7 +199,6 @@ class TestCase(unittest.TestCase):
         self._with_csrf = False
 
     def assertDatabaseHas(self, schema, value):
-        #schema = table.column
         from config.database import DB
 
         table = schema.split('.')[0]

--- a/masonite/testing/TestCase.py
+++ b/masonite/testing/TestCase.py
@@ -1,6 +1,5 @@
 import io
 import json
-import subprocess
 import unittest
 from contextlib import contextmanager
 from urllib.parse import urlencode
@@ -209,7 +208,6 @@ class TestCase(unittest.TestCase):
         self.assertTrue(DB.table(table).where(column, value).first())
 
     def assertDatabaseNotHas(self, schema, value):
-        #schema = table.column
         from config.database import DB
 
         table = schema.split('.')[0]

--- a/masonite/testing/TestCase.py
+++ b/masonite/testing/TestCase.py
@@ -198,3 +198,21 @@ class TestCase(unittest.TestCase):
 
     def withoutCsrf(self):
         self._with_csrf = False
+
+    def assertDatabaseHas(self, schema, value):
+        #schema = table.column
+        from config.database import DB
+
+        table = schema.split('.')[0]
+        column = schema.split('.')[1]
+
+        self.assertTrue(DB.table(table).where(column, value).first())
+
+    def assertDatabaseNotHas(self, schema, value):
+        #schema = table.column
+        from config.database import DB
+
+        table = schema.split('.')[0]
+        column = schema.split('.')[1]
+
+        self.assertFalse(DB.table(table).where(column, value).first())

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     licence=meta['__licence__'],
     python_requires=">=3.4",
     classifiers=[
-        'Development Status :: 5 - Production',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Masonite',
         'Intended Audience :: Developers',

--- a/tests/testing/test_route_tests.py
+++ b/tests/testing/test_route_tests.py
@@ -61,7 +61,7 @@ class TestUnitTest(TestCase):
     def test_json_response(self):
         self.assertTrue(self.json('GET', '/unit/test/json/response').hasJson('count', 5))
 
-    def test_json_response(self):
+    def test_json_response_dictionary(self):
         self.assertTrue(self.json('GET', '/unit/test/json/response').hasJson({
             'count': 5
         }))

--- a/tests/testing/test_route_tests.py
+++ b/tests/testing/test_route_tests.py
@@ -95,3 +95,7 @@ class TestUnitTest(TestCase):
         self.withCsrf()
         with self.assertRaises(InvalidCSRFToken):
             self.assertTrue(self.post('/unit/test/json', {'test': 'testing'}).contains('testing'))
+
+    def test_database_has(self):
+        self.assertDatabaseHas('users.email', 'user@example.com')
+        self.assertDatabaseNotHas('users.email', 'joe@example.com')


### PR DESCRIPTION
Added new `assertDatabaseHas` which can be used like this:

```python
def setUpFactories(self):
    User.create({
        'name': 'Joe',
        'email': 'user@example.com',
        'password': 'secret'
    })

def test_database_has(self):
    self.assertDatabaseHas('users.email', 'user@example.com')
    self.assertDatabaseNotHas('users.email', 'joe@example.com')
```