### PR TITLE
added then_back

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -11,7 +11,7 @@ of this class.
 import re
 from cgi import MiniFieldStorage
 from http import cookies
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlencode
 
 import tldextract
 from cryptography.fernet import InvalidToken
@@ -647,6 +647,10 @@ class Request(Extendable):
             self.redirect_url = self.url_from_controller(controller, params)
 
         self.status(status)
+        return self
+
+    def then_back(self, url=None):
+        self.redirect_url = self.redirect_url + '?' + urlencode({'back': url or self.path}, safe='/')
         return self
 
     def redirect_to(self, route_name, params={}, status=302):

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -1,6 +1,5 @@
 import unittest
 from cgi import MiniFieldStorage
-from pydoc import locate
 
 import pytest
 from masonite.app import App

--- a/tests/core/test_requests.py
+++ b/tests/core/test_requests.py
@@ -684,3 +684,16 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(self.request.input('key.user'), '1')
         self.assertEqual(self.request.input('key.nothing'), False)
         self.assertEqual(self.request.input('key.nothing', default='test'), 'test')
+
+    def test_then_back(self):
+        self.request.redirect('/login')
+        self.assertEqual(self.request.redirect_url, '/login')
+
+        self.request.redirect('/login').then_back('/dashboard')
+
+        self.assertEqual(self.request.redirect_url, '/login?back=/dashboard')
+
+        self.request.path = '/dashboard'
+        self.request.redirect('/login').then_back()
+
+        self.assertEqual(self.request.redirect_url, '/login?back=/dashboard')


### PR DESCRIPTION
This is a useful method that can be used like this:

```python
request.redirect('/login').then_back()
```

This will result in redirecting to a URL like `/login?back=/dashboard`

It will default to redirecting back to the current route. You can also redirect to a specific route:

```python
request.redirect('/login').then_back('/another/route')
```
When it redirects to something like your login page you can use the `back()` helper:

```html
<form action="/login" method="POST">
    {{ csrf_field }}
    {{ back() }}
</form>
```

When this submits you can then redirect in your controller like normal

```
def store(self, request: Request):
    .. code ..
    request.back()
```

which in this case will redirect to the dashboard. 

All that changes in this PR is that the URL is that is built. All other functionality is already done

Closes #717 