### PR TITLE
fixed issue when acting as user of a wrong type

### DIFF
--- a/masonite/testing/TestCase.py
+++ b/masonite/testing/TestCase.py
@@ -150,6 +150,8 @@ class TestCase(unittest.TestCase):
         return self.json('DELETE', url, params)
 
     def actingAs(self, user):
+        if not user:
+            raise TypeError("Cannot act as a user of type: {}".format(type(user)))
         self.acting_user = user
         return self
 

--- a/tests/testing/test_route_tests.py
+++ b/tests/testing/test_route_tests.py
@@ -99,3 +99,7 @@ class TestUnitTest(TestCase):
     def test_database_has(self):
         self.assertDatabaseHas('users.email', 'user@example.com')
         self.assertDatabaseNotHas('users.email', 'joe@example.com')
+
+    def test_acting_as_none(self):
+        with self.assertRaises(TypeError):
+            self.actingAs(User.find(10)).get('/helloworld')


### PR DESCRIPTION
Fixed when logging in as a user that does not exist. This was getting farther down the route tree than normal and its not apparently clear that the user doesn't exist.

So when trying to hit a route with a user you think you are acting as, you will not be able to see what the issue is when you can't hit the route

Closes #772 