### PR TITLE
fixes issue with caching of route params

### DIFF
--- a/masonite/request.py
+++ b/masonite/request.py
@@ -747,6 +747,7 @@ class Request(Extendable):
             try:
                 route = self._get_named_route(name, params)
             except KeyError:
+                params = {}
                 params.update(self.url_params)
                 route = self._get_named_route(name, params)
 


### PR DESCRIPTION
This fixes an issue when using the `{{ route('route.name') }}` without route params.

Sometimes the routes act like they are being cached