### PR TITLE
Feature/599 - Add a database Queue driver

### DIFF
--- a/app/http/controllers/UnitTestController.py
+++ b/app/http/controllers/UnitTestController.py
@@ -36,7 +36,7 @@ class UnitTestController(Controller):
     def response(self):
         return {
             'count': 5,
-            'iterable': [1,2,3]
+            'iterable': [1, 2, 3]
         }
 
     def multi(self):
@@ -45,6 +45,9 @@ class UnitTestController(Controller):
                 'name': 'Joe'
             }
         }
+
+    def multi_count(self):
+        return {"count": 5, "iterable": [1, 2, 3]}
 
     def patch(self):
         return self.request.input('test')

--- a/config/application.py
+++ b/config/application.py
@@ -56,3 +56,5 @@ them in but feel free to autoload any directories
 AUTOLOAD = [
     'app',
 ]
+
+FALSY = False

--- a/config/database.py
+++ b/config/database.py
@@ -26,7 +26,7 @@ DATABASES = {
     'default': env('DB_CONNECTION', 'sqlite'),
     'sqlite': {
         'driver': 'sqlite',
-        'database': env('DB_DATABASE', 'masonite.db'),
+        'database': env('SQLITE_DB_DATABASE', 'masonite.db'),
         'log_queries': env('DB_LOG'),
         'prefix': ''
     },

--- a/masonite/__version__.py
+++ b/masonite/__version__.py
@@ -2,7 +2,7 @@
 __title__ = 'masonite'
 __description__ = 'The core for the Masonite framework'
 __url__ = 'https://github.com/MasoniteFramework/masonite'
-__version__ = '2.2.15'
+__version__ = '2.2.16'
 __author__ = 'Joseph Mancuso'
 __author_email__ = 'joe@masoniteproject.com'
 __licence__ = 'MIT'

--- a/masonite/commands/MigrateCommand.py
+++ b/masonite/commands/MigrateCommand.py
@@ -11,11 +11,12 @@ class MigrateCommand(Command):
     Run migrations.
 
     migrate
+        {--c|connection=default : The connection you want to run migrations on}
     """
 
     def handle(self):
         sys.path.append(os.getcwd())
-        migrations = Migrations().run()
+        migrations = Migrations(self.option('connection')).run()
         self.line("")
         for notes in migrations._notes:
             self.line(notes)

--- a/masonite/commands/MigrateRefreshCommand.py
+++ b/masonite/commands/MigrateRefreshCommand.py
@@ -9,11 +9,16 @@ class MigrateRefreshCommand(Command):
 
     migrate:refresh
         {--s|seed : Seed the database}
+        {--c|connection=default : The connection you want to run migrations on}
     """
 
     def handle(self):
-        self.call('migrate:reset')
-        self.call('migrate')
+        self.call('migrate:reset', [
+            ('--connection', self.option('connection'))
+        ])
+        self.call('migrate', [
+            ('--connection', self.option('connection'))
+        ])
 
         if self.option('seed'):
             self.call('seed:run')

--- a/masonite/commands/MigrateResetCommand.py
+++ b/masonite/commands/MigrateResetCommand.py
@@ -11,11 +11,12 @@ class MigrateResetCommand(Command):
     Migrate reset.
 
     migrate:reset
+        {--c|connection=default : The connection you want to run migrations on}
     """
 
     def handle(self):
         sys.path.append(os.getcwd())
-        migrations = Migrations().reset()
+        migrations = Migrations(self.option('connection')).reset()
         self.line("")
         for notes in migrations._notes:
             self.line(notes)

--- a/masonite/commands/MigrateRollbackCommand.py
+++ b/masonite/commands/MigrateRollbackCommand.py
@@ -11,11 +11,12 @@ class MigrateRollbackCommand(Command):
     Migrate Rollback.
 
     migrate:rollback
+        {--c|connection=default : The connection you want to run migrations on}
     """
 
     def handle(self):
         sys.path.append(os.getcwd())
-        migrations = Migrations().rollback()
+        migrations = Migrations(self.option('connection')).rollback()
         self.line("")
         for notes in migrations._notes:
             self.line(notes)

--- a/masonite/commands/QueueTableCommand.py
+++ b/masonite/commands/QueueTableCommand.py
@@ -11,8 +11,13 @@ class QueueTableCommand(Command):
     Create migration files for the queue feature
 
     queue:table
+        {--failed : Created the queue failed table}
+        {--jobs : Created the queue failed table}
     """
 
     def handle(self):
-        copy_migration('masonite/snippets/migrations/create_failed_jobs_table.py')
+        if self.option('failed'):
+            copy_migration('masonite/snippets/migrations/create_failed_jobs_table.py')
+        if self.option('jobs'):
+            copy_migration('masonite/snippets/migrations/create_queue_jobs_table.py')
         self.info('Migration created successfully')

--- a/masonite/drivers/__init__.py
+++ b/masonite/drivers/__init__.py
@@ -15,6 +15,7 @@ from .mail.MailLogDriver import MailLogDriver
 from .mail.MailTerminalDriver import MailTerminalDriver
 from .queue.QueueAsyncDriver import QueueAsyncDriver
 from .queue.QueueAmqpDriver import QueueAmqpDriver
+from .queue.QueueDatabaseDriver import QueueDatabaseDriver
 from .session.SessionCookieDriver import SessionCookieDriver
 from .session.SessionMemoryDriver import SessionMemoryDriver
 from .storage.StorageDiskDriver import StorageDiskDriver

--- a/masonite/drivers/queue/BaseQueueDriver.py
+++ b/masonite/drivers/queue/BaseQueueDriver.py
@@ -10,7 +10,7 @@ from masonite.helpers import HasColoredCommands
 
 class BaseQueueDriver(BaseDriver, HasColoredCommands):
 
-    def add_to_failed_queue_table(self, payload):
+    def add_to_failed_queue_table(self, payload, driver='amqp'):
         from config.database import DB as schema
         from config import queue
         if 'amqp' in queue.DRIVERS:
@@ -20,7 +20,7 @@ class BaseQueueDriver(BaseDriver, HasColoredCommands):
 
         if schema.get_schema_builder().has_table('failed_jobs'):
             schema.table('failed_jobs').insert({
-                'driver': 'amqp',
+                'driver': driver,
                 'channel': listening_channel,
                 'payload': pickle.dumps(payload),
                 'failed_at': pendulum.now()

--- a/masonite/drivers/queue/QueueAmqpDriver.py
+++ b/masonite/drivers/queue/QueueAmqpDriver.py
@@ -59,7 +59,7 @@ class QueueAmqpDriver(BaseQueueDriver, QueueContract, HasColoredCommands):
 
             try:
                 self._publish(payload)
-            except (self.pika.exceptions.ConnectionClosed, self.pika.exceptions.ChannelClosed) + additional_exceptions:
+            except ((self.pika.exceptions.ConnectionClosed, self.pika.exceptions.ChannelClosed), additional_exceptions):
                 self.connect()
                 self._publish(payload)
 

--- a/masonite/drivers/queue/QueueAmqpDriver.py
+++ b/masonite/drivers/queue/QueueAmqpDriver.py
@@ -40,7 +40,7 @@ class QueueAmqpDriver(BaseQueueDriver, QueueContract, HasColoredCommands):
         self.channel.close()
         self.connection.close()
 
-    def push(self, *objects, args=(), callback='handle', ran=1, channel=None):
+    def push(self, *objects, args=(), callback='handle', ran=1, channel=None, **options):
         """Push objects onto the amqp stack.
 
         Arguments:

--- a/masonite/drivers/queue/QueueDatabaseDriver.py
+++ b/masonite/drivers/queue/QueueDatabaseDriver.py
@@ -1,0 +1,125 @@
+"""Async Driver Method."""
+
+import inspect
+import pickle
+import time
+
+import pendulum
+from masonite.contracts import QueueContract
+from masonite.drivers import BaseQueueDriver
+from masonite.helpers import HasColoredCommands, parse_human_time
+from masonite.queues import Queueable
+
+
+class QueueDatabaseDriver(BaseQueueDriver, HasColoredCommands, QueueContract):
+    """Queue Aysnc Driver."""
+
+    def __init__(self):
+        """Queue Async Driver.
+
+        Arguments:
+            Container {masonite.app.App} -- The application container.
+        """
+        pass
+
+    def connect(self):
+        return self
+
+    def push(self, *objects, args=(), kwargs={}, **options):
+        """Push objects onto the async stack.
+
+        Arguments:
+            objects {*args of objects} - This can be several objects as parameters into this method.
+            options {**kwargs of options} - Additional options for async driver
+        """
+
+        from config.database import DB as schema
+        from config import queue
+
+        callback = options.get('callback', 'handle')
+        wait = options.get('wait', None)
+
+        if wait:
+            wait = parse_human_time(wait).to_datetime_string()
+
+        for job in objects:
+            if schema.get_schema_builder().has_table('queue_jobs'):
+                payload = pickle.dumps({'obj': job, 'args': args, 'callback': callback})
+                schema.table('queue_jobs').insert({
+                    'name': str(job),
+                    'serialized': payload,
+                    'created_at': pendulum.now().to_datetime_string(),
+                    'attempts': 0,
+                    'ran_at': None,
+                    'wait_until': wait,
+                })
+
+    def consume(self, channel, fair=False):
+        from config.database import DB as schema
+        from config import queue
+        from wsgi import container
+
+        self.info('[*] Waiting to process jobs from the "queue_jobs" table. To exit press CTRL + C')
+        while True:
+            jobs = schema.table('queue_jobs').where('ran_at', None).get()
+            if not jobs.count():
+                time.sleep(5)
+
+            for job in jobs:
+                unserialized = pickle.loads(job.serialized)
+                obj = unserialized['obj']
+                args = unserialized['args']
+                callback = unserialized['callback']
+                ran = job.attempts
+
+                if job['wait_until'] and pendulum.instance(job['wait_until']).is_future():
+                    continue
+                try:
+                    try:
+                        if inspect.isclass(obj):
+                            obj = container.resolve(obj)
+
+                        getattr(obj, callback)(*args)
+
+                    except AttributeError:
+                        obj(*args)
+
+                    try:
+                        # attempts = 1
+                        schema.table('queue_jobs').where('id', job['id']).update({
+                            'ran_at': pendulum.now().to_datetime_string(),
+                            'attempts': job['attempts'] + 1,
+                        })
+                        self.success('[\u2713] Job Successfully Processed')
+                    except UnicodeEncodeError:
+                        self.success('[Y] Job Successfully Processed')
+                except Exception as e:
+                    self.danger('Job Failed: {}'.format(str(e)))
+
+                    if not obj.run_again_on_fail:
+                        # ch.basic_ack(delivery_tag=method.delivery_tag)
+                        schema.table('queue_jobs').where('id', job['id']).update({
+                            'ran_at': pendulum.now().to_datetime_string(),
+                            'failed': 1,
+                            'attempts': job['attempts'] + 1,
+                        })
+
+                    if ran < obj.run_times and isinstance(obj, Queueable):
+                        time.sleep(1)
+                        schema.table('queue_jobs').where('id', job['id']).update({
+                            'attempts': job['attempts'] + 1,
+                        })
+                        continue
+                    else:
+                        schema.table('queue_jobs').where('id', job['id']).update({
+                            'attempts': job['attempts'] + 1,
+                            'ran_at': pendulum.now().to_datetime_string(),
+                            'failed': 1,
+                        })
+
+                        if hasattr(obj, 'failed'):
+                            getattr(obj, 'failed')(unserialized, str(e))
+
+                        self.add_to_failed_queue_table(unserialized, driver='database')
+
+            time.sleep(5)

--- a/masonite/helpers/__init__.py
+++ b/masonite/helpers/__init__.py
@@ -2,7 +2,7 @@ from .static import static
 from .password import password
 from .misc import random_string, dot, clean_request_input, HasColoredCommands, Compact as compact, deprecated
 from .Extendable import Extendable
-from .time import cookie_expire_time
+from .time import cookie_expire_time, parse_human_time
 from .optional import Optional as optional
 from .structures import config, Dot
 from .migrations import has_unmigrated_migrations

--- a/masonite/helpers/migrations.py
+++ b/masonite/helpers/migrations.py
@@ -7,12 +7,17 @@ from orator.migrations import DatabaseMigrationRepository, Migrator
 
 class Migrations(HasColoredCommands):
 
-    def __init__(self):
+    def __init__(self, connection=None):
         self._ran = []
         self._notes = []
         from config import database
+        database_dict = database.DB
+
         self.repository = DatabaseMigrationRepository(database.DB, 'migrations')
         self.migrator = Migrator(self.repository, database.DB)
+        if not connection or connection == 'default':
+            connection = database.DATABASES['default']
+        self.migrator.set_connection(connection)
         if not self.repository.repository_exists():
             self.repository.create_repository()
 

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -47,8 +47,12 @@ class Dot:
                         return collect(dic).pluck(searching[searching.index('*') + 1]).serialize()
                     except KeyError:
                         return []
-                dic = dic.get(value)
+                
+                if not isinstance(dic, dict):
+                    return default
 
+                dic = dic.get(value)
+                
                 if isinstance(dic, str) and dic.isnumeric():
                     continue
 
@@ -124,7 +128,7 @@ class Dot:
 
         value = pydoc.locate('.'.join(paths[:-1]) + '.' + paths[-1].upper())
 
-        if value:
+        if value or value is False:
             return value
 
         search_path = -1

--- a/masonite/helpers/structures.py
+++ b/masonite/helpers/structures.py
@@ -1,7 +1,8 @@
 """A Module For Manipulating Code Structures."""
 
-import pydoc
 import inspect
+import pydoc
+
 from orator.support.collection import Collection as collect
 
 
@@ -47,12 +48,12 @@ class Dot:
                         return collect(dic).pluck(searching[searching.index('*') + 1]).serialize()
                     except KeyError:
                         return []
-                
+
                 if not isinstance(dic, dict):
                     return default
 
                 dic = dic.get(value)
-                
+
                 if isinstance(dic, str) and dic.isnumeric():
                     continue
 

--- a/masonite/helpers/time.py
+++ b/masonite/helpers/time.py
@@ -34,3 +34,36 @@ def cookie_expire_time(str_time):
         return None
     else:
         return pendulum.now('GMT').subtract(years=20).format('%a, %d %b %Y %H:%M:%S GMT')
+
+
+def parse_human_time(str_time):
+    """Take a string like 1 month or 5 minutes and returns a pendulum instance.
+
+    Arguments:
+        str_time {string} -- Could be values like 1 second or 3 minutes
+
+    Returns:
+        pendlum -- Returns Pendulum instance
+    """
+    if str_time != 'expired':
+        number = int(str_time.split(" ")[0])
+        length = str_time.split(" ")[1]
+
+        if length in ('second', 'seconds'):
+            return pendulum.now('GMT').add(seconds=number)
+        elif length in ('minute', 'minutes'):
+            return pendulum.now('GMT').add(minutes=number)
+        elif length in ('hour', 'hours'):
+            return pendulum.now('GMT').add(hours=number)
+        elif length in ('days', 'days'):
+            return pendulum.now('GMT').add(days=number)
+        elif length in ('week', 'weeks'):
+            return pendulum.now('GMT').add(weeks=1)
+        elif length in ('month', 'months'):
+            return pendulum.now('GMT').add(months=number)
+        elif length in ('year', 'years'):
+            return pendulum.now('GMT').add(years=number)
+
+        return None
+    else:
+        return pendulum.now('GMT').subtract(years=20)

--- a/masonite/providers/QueueProvider.py
+++ b/masonite/providers/QueueProvider.py
@@ -1,7 +1,7 @@
 """A RedirectionProvider Service Provider."""
 
 
-from masonite.drivers import QueueAsyncDriver, QueueAmqpDriver
+from masonite.drivers import QueueAsyncDriver, QueueAmqpDriver, QueueDatabaseDriver
 from masonite.managers import QueueManager
 from masonite.provider import ServiceProvider
 from masonite import Queue
@@ -14,6 +14,7 @@ class QueueProvider(ServiceProvider):
     def register(self):
         from config import queue
         self.app.bind('QueueAsyncDriver', QueueAsyncDriver)
+        self.app.bind('QueueDatabaseDriver', QueueDatabaseDriver)
         self.app.bind('QueueAmqpDriver', QueueAmqpDriver)
         self.app.bind('QueueManager', QueueManager)
         self.app.bind('QueueConfig', queue)

--- a/masonite/queues/Queueable.py
+++ b/masonite/queues/Queueable.py
@@ -18,3 +18,6 @@ class Queueable:
             self.handle
         """
         return self.handle
+
+    def should_run(self, job):
+        return True

--- a/masonite/snippets/auth/controllers/ConfirmController.py
+++ b/masonite/snippets/auth/controllers/ConfirmController.py
@@ -7,8 +7,6 @@ from masonite.managers import MailManager
 from masonite.request import Request
 from masonite.view import View
 
-from app.User import User
-
 
 class ConfirmController:
     """The ConfirmController class."""

--- a/masonite/snippets/migrations/create_queue_jobs_table.py
+++ b/masonite/snippets/migrations/create_queue_jobs_table.py
@@ -10,7 +10,7 @@ class CreateQueueJobsTable(Migration):
             table.string('name')
             table.binary('serialized')
             table.integer('attempts')
-            table.integer('failed')
+            table.integer('failed').nullable()
             table.timestamp('ran_at').nullable()
             table.timestamp('created_at').nullable()
             table.timestamp('wait_until').nullable()

--- a/masonite/snippets/migrations/create_queue_jobs_table.py
+++ b/masonite/snippets/migrations/create_queue_jobs_table.py
@@ -11,9 +11,9 @@ class CreateQueueJobsTable(Migration):
             table.binary('serialized')
             table.integer('attempts')
             table.integer('failed')
-            table.timestamp('ran_at')
-            table.timestamp('created_at')
-            table.timestamp('wait_until')
+            table.timestamp('ran_at').nullable()
+            table.timestamp('created_at').nullable()
+            table.timestamp('wait_until').nullable()
 
     def down(self):
         """Revert the migrations."""

--- a/masonite/snippets/migrations/create_queue_jobs_table.py
+++ b/masonite/snippets/migrations/create_queue_jobs_table.py
@@ -1,0 +1,20 @@
+from orator.migrations import Migration
+
+
+class CreateQueueJobsTable(Migration):
+
+    def up(self):
+        """Run the migrations."""
+        with self.schema.create('queue_jobs') as table:
+            table.increments('id')
+            table.string('name')
+            table.binary('serialized')
+            table.integer('attempts')
+            table.integer('failed')
+            table.timestamp('ran_at')
+            table.timestamp('created_at')
+            table.timestamp('wait_until')
+
+    def down(self):
+        """Revert the migrations."""
+        self.schema.drop('queue_jobs')

--- a/masonite/testing/MockRoute.py
+++ b/masonite/testing/MockRoute.py
@@ -37,8 +37,8 @@ class MockRoute:
     def hasJson(self, key, value=''):
         response = json.loads(self.container.make('Response'))
         if isinstance(key, dict):
-            for item_key, value in key.items():
-                if not Dot().dot(item_key, response, False) == value:
+            for item_key, key_value in key.items():
+                if not Dot().dot(item_key, response, False) == key_value:
                     return False
             return True
         return Dot().dot(key, response, False)

--- a/masonite/testing/MockRoute.py
+++ b/masonite/testing/MockRoute.py
@@ -158,3 +158,13 @@ class MockRoute:
     @property
     def request(self):
         return self.container.make('Request')
+
+    @property
+    def response(self):
+        return self.container.make('Response')
+
+    def asDictionary(self):
+        try:
+            return json.loads(self.response)
+        except ValueError:
+            raise ValueError("The response was not json serializable")

--- a/masonite/testing/TestCase.py
+++ b/masonite/testing/TestCase.py
@@ -211,7 +211,6 @@ class TestCase(unittest.TestCase):
         wsgi.update(wsgi_values)
         self.container.bind('Environ', wsgi)
         self.container.make('Request')._test_user = self.acting_user
-        print(id(self.container))
         self.container.make('Request').load_app(self.container)
         if self._with_subdomains:
             self.container.make('Request').activate_subdomains()

--- a/routes/web.py
+++ b/routes/web.py
@@ -32,6 +32,7 @@ ROUTES = [
         Get('/test/json/response', 'UnitTestController@response'),
         Post('/test/json/validate', 'UnitTestController@validate'),
         Get('/test/json/multi', 'UnitTestController@multi'),
+        Get('/test/json/multi_count', 'UnitTestController@multi_count'),
         Patch('/test/patch', 'UnitTestController@patch'),
     ], prefix="/unit")
 ]

--- a/tests/helpers/test_config.py
+++ b/tests/helpers/test_config.py
@@ -14,6 +14,9 @@ class TestConfig(unittest.TestCase):
     def test_config_can_get_value_from_file(self):
         self.assertEqual(self.config('application.DEBUG'), True)
 
+    def test_config_can_get_value_from_file_that_is_false(self):
+        self.assertEqual(self.config('application.FALSY'), False)
+
     def test_config_can_get_dict_value_lowercase(self):
         self.assertEqual(self.config('application.debug'), True)
 

--- a/tests/helpers/test_dot_notation.py
+++ b/tests/helpers/test_dot_notation.py
@@ -23,6 +23,7 @@ class TestDot(unittest.TestCase):
         self.assertEqual(DictDot().dot('key.test.layer', {'key': {'test': {'layer': 'value'}}}), 'value')
         self.assertEqual(DictDot().dot('key.none', {'key': {'test': {'layer': 'value'}}}), None)
         self.assertEqual(DictDot().dot('key', {'key': {'test': {'layer': 'value'}}}), {'test': {'layer': 'value'}})
+        self.assertEqual(DictDot().dot('key.test.none', {'key': 'value'}), None)
 
     def test_dict_dot_asterisk(self):
         payload = {

--- a/tests/testing/test_route_tests.py
+++ b/tests/testing/test_route_tests.py
@@ -77,6 +77,14 @@ class TestUnitTest(TestCase):
         }))
 
         self.assertTrue(self.json('GET', '/unit/test/json/multi').hasJson('author.name', 'Joe'))
+        self.assertFalse(self.json('GET', '/unit/test/json/multi_count').hasJson('count.foo', 'foo'))
+
+    def test_as_dictionary(self):
+        dictionary = self.json('GET', '/unit/test/json/multi').asDictionary()
+        self.assertEqual(dictionary['author']['name'], 'Joe')
+
+        with self.assertRaises(ValueError):
+            dictionary = self.json('GET', '/login').asDictionary()
 
     def test_count(self):
         self.assertTrue(self.json('GET', '/unit/test/json/response').count(2))


### PR DESCRIPTION
Closes #599 

# Documentation

Install from this branch

```
$ pip install https://github.com/masoniteframework/core/archive/feature/599.zip
```

First you will need to create the migration for your queue jobs:

```
$ craft queue:table --jobs
```

If you want to have a table where failed jobs will be stored, you can create a migration for that table as well. If this table does not exist, any failed jobs will simply stay failed.

```
$ craft queue:table --failed
```

Change the database configuration to use the `database` driver:

```python
DRIVER = 'database'
```

Or you can leave the queue driver as is and specify the driver directly with the `Queue` class:

```python
from masonite.queue import Queue

def show(self, queue: Queue):
    queue.driver('database').push(..)
```

## Waiting

With the database driver, you have the ability to use the `wait` keyword. To queue a job to run 10 minutes from now you can do something like:

```python
from masonite.queue import Queue
from app.jobs import SomeJob

def show(self, queue: Queue):
    queue.driver('database').push(SomeJob, args=(arg1, arg2), wait="10 minutes")
```

## Running the worker

The database driver, like the amqp driver, requires a worker to be running. You can run the worker by using the `queue:work` command:

```bash
$ craft queue:work --driver database
```

This will start a worker that will poll the database for new jobs every 5 seconds. Once new jobs are found it will run them all and then continue waiting for new jobs. If any jobs fail they will run 3 more times. If the job still fails it will be added to the `failed_jobs` if one exists. If one does not exist it will stay failed inside the `queue_jobs` table.

You can still run failed jobs by running 

```
$ craft queue:work --driver database --failed 
```