### PR TITLE
directly returning a Paginator or LengthAwarePaginator instance

### DIFF
--- a/masonite/response.py
+++ b/masonite/response.py
@@ -8,6 +8,8 @@ from masonite.view import View
 
 from orator.support.collection import Collection
 from orator import Model
+from orator.pagination.length_aware_paginator import LengthAwarePaginator
+from orator.pagination.paginator import Paginator
 from masonite.app import App
 
 
@@ -36,6 +38,86 @@ class Response(Extendable):
         self.request.status(status)
 
         return self.data()
+
+    def paginated_json(self, paginator, status=200):
+        """Determine type of paginated instance and return JSON response.
+
+        Arguments:
+            paginator {Paginator|LengthAwarePaginator} --
+                Either an Orator Paginator or LengthAwarePaginator object
+
+        Returns:
+            string -- Returns a string representation of the data
+        """
+        # configured param types
+        PAGE_SIZE_PARAM = 'page_size'
+        PAGE_PARAM = 'page'
+
+        # try to capture request input for page_size and/or page
+        page_size_input = self.request.input(PAGE_SIZE_PARAM)
+        page_input = self.request.input(PAGE_PARAM)
+        # use try/except here, as int(bool) will return 0 for False above
+        try:
+            page_size = (
+                int(page_size_input)
+                if page_size_input and int(page_size_input) > 0
+                else paginator.per_page
+            )
+        except Exception as _:
+            page_size = paginator.per_page
+        try:
+            page = (
+                int(page_input)
+                if page_input  and int(page_input) > 0
+                else paginator.current_page
+            )
+        except Exception as _:
+            page = paginator.current_page
+
+        # don't waste time instantiating new paginator if no change
+        if (
+            page_size != paginator.per_page
+            or page != paginator.current_page
+        ):
+            try:
+                # try to get class of model
+                model_class = next(type(x) for x in paginator.items)
+                if model_class:
+                    if isinstance(paginator, Paginator):
+                        paginator = model_class.simple_paginate(
+                            page_size,
+                            page
+                        )
+                    elif isinstance(paginator, LengthAwarePaginator):
+                        paginator = model_class.paginate(page_size, page)
+            except Exception as _:
+                paginator = paginator
+
+        payload = {
+            'total': (
+                paginator.total
+                if isinstance(paginator, LengthAwarePaginator)
+                else None
+            ),
+            'count': paginator.count(),
+            'per_page': page_size,
+            'current_page': page,
+            'last_page': (
+                paginator.last_page
+                if isinstance(paginator, LengthAwarePaginator)
+                else None
+            ),
+            'from': (page_size * (page- 1)) + 1,
+            'to': page_size * page,
+            'data': paginator.serialize()
+        }
+
+        # remove fields not relevant to Paginator instance
+        if isinstance(paginator, Paginator):
+            del payload['total']
+            del payload['last_page']
+
+        return self.json(payload, status)
 
     def make_headers(self, content_type="text/html; charset=utf-8"):
         """Make the appropriate headers based on changes made in controllers or middleware.
@@ -99,6 +181,8 @@ class Response(Extendable):
             view = view.rendered_template
         elif isinstance(view, self.request.__class__):
             view = self.data()
+        if isinstance(view, (Paginator, LengthAwarePaginator)):
+            return self.paginated_json(view, status=self.request.get_status())
         elif view is None:
             raise ResponseError('Responses cannot be of type: None.')
 

--- a/masonite/response.py
+++ b/masonite/response.py
@@ -8,8 +8,7 @@ from masonite.view import View
 
 from orator.support.collection import Collection
 from orator import Model
-from orator.pagination.length_aware_paginator import LengthAwarePaginator
-from orator.pagination.paginator import Paginator
+from orator import Paginator, LengthAwarePaginator
 from masonite.app import App
 
 

--- a/masonite/response.py
+++ b/masonite/response.py
@@ -68,7 +68,7 @@ class Response(Extendable):
         try:
             page = (
                 int(page_input)
-                if page_input  and int(page_input) > 0
+                if page_input and int(page_input) > 0
                 else paginator.current_page
             )
         except Exception as _:

--- a/tests/core/test_response.py
+++ b/tests/core/test_response.py
@@ -1,7 +1,9 @@
 import unittest
+import json
 
 from orator import Model
 from orator.support.collection import Collection
+from orator import Paginator, LengthAwarePaginator
 
 from app.http.controllers.TestController import \
     TestController as ControllerTest
@@ -94,3 +96,81 @@ class TestResponse(unittest.TestCase):
 
         self.assertIn('"name": "TestUser"', self.app.make('Response'))
         self.assertIn('"email": "user@email.com"', self.app.make('Response'))
+
+    def test_view_should_return_a_json_response_when_returning_length_aware_paginator_instance(self):
+
+        self.assertIsInstance(MockUser(), Model)
+        users = MockUser().all()
+        num_users = len(users)
+        page_size = 15
+        self.response.view(LengthAwarePaginator(users, num_users, page_size))
+
+        self.assertIn('"total": {}'.format(num_users), self.app.make('Response'))
+        self.assertIn('"count": {}'.format(num_users), self.app.make('Response'))
+        self.assertIn('"per_page": {}'.format(page_size), self.app.make('Response'))
+        self.assertIn('"current_page": 1', self.app.make('Response'))
+        self.assertIn('"last_page": 1', self.app.make('Response'))
+        self.assertIn('"from": 1', self.app.make('Response'))
+        self.assertIn('"to": {}'.format(page_size), self.app.make('Response'))
+        self.assertIn('"data": ', self.app.make('Response'))
+        self.assertIn(
+            {'name': 'TestUser', 'email': 'user@email.com'},
+            json.loads(self.app.make('Response'))['data']
+        )
+
+        users = [MockUser().find(1)]
+        num_users = len(users)
+        default_page_size = 15
+        page_size_param = 10
+        self.request._set_standardized_request_variables({'page_size': str(page_size_param)})
+        self.response.view(LengthAwarePaginator(users, num_users, default_page_size))
+
+        self.assertIn('"total": {}'.format(num_users), self.app.make('Response'))
+        self.assertIn('"count": {}'.format(num_users), self.app.make('Response'))
+        self.assertIn('"per_page": {}'.format(page_size_param), self.app.make('Response'))
+        self.assertIn('"current_page": 1', self.app.make('Response'))
+        self.assertIn('"last_page": 1', self.app.make('Response'))
+        self.assertIn('"from": 1', self.app.make('Response'))
+        self.assertIn('"to": {}'.format(page_size_param), self.app.make('Response'))
+        self.assertIn('"data": ', self.app.make('Response'))
+        self.assertIn(
+            {'name': 'TestUser', 'email': 'user@email.com'},
+            json.loads(self.app.make('Response'))['data']
+        )
+
+    def test_view_should_return_a_json_response_when_returning_paginator_instance(self):
+
+        self.assertIsInstance(MockUser(), Model)
+        users = MockUser().all()
+        num_users = len(users)
+        page_size = 15
+        self.response.view(Paginator(users, page_size))
+
+        self.assertIn('"count": {}'.format(num_users), self.app.make('Response'))
+        self.assertIn('"per_page": {}'.format(page_size), self.app.make('Response'))
+        self.assertIn('"current_page": 1', self.app.make('Response'))
+        self.assertIn('"from": 1', self.app.make('Response'))
+        self.assertIn('"to": {}'.format(page_size), self.app.make('Response'))
+        self.assertIn('"data": ', self.app.make('Response'))
+        self.assertIn(
+            {'name': 'TestUser', 'email': 'user@email.com'},
+            json.loads(self.app.make('Response'))['data']
+        )
+
+        users = [MockUser().find(1)]
+        num_users = len(users)
+        default_page_size = 15
+        page_size_param = 10
+        self.request._set_standardized_request_variables({'page_size': str(page_size_param)})
+        self.response.view(Paginator(users, default_page_size))
+
+        self.assertIn('"count": {}'.format(num_users), self.app.make('Response'))
+        self.assertIn('"per_page": {}'.format(page_size_param), self.app.make('Response'))
+        self.assertIn('"current_page": 1', self.app.make('Response'))
+        self.assertIn('"from": 1', self.app.make('Response'))
+        self.assertIn('"to": {}'.format(page_size_param), self.app.make('Response'))
+        self.assertIn('"data": ', self.app.make('Response'))
+        self.assertIn(
+            {'name': 'TestUser', 'email': 'user@email.com'},
+            json.loads(self.app.make('Response'))['data']
+        )


### PR DESCRIPTION
directly returning a Paginator or LengthAwarePaginator instance from a controller now creates a JSON response. The JSON response includes the collection data as well as the meta data regarding paginated collection.