### PR TITLE
Added route resources Feature/404

### DIFF
--- a/app/http/controllers/UserResourceController.py
+++ b/app/http/controllers/UserResourceController.py
@@ -1,0 +1,61 @@
+""" A UserResourceController Module """
+
+from masonite.controllers import Controller
+
+
+class UserResourceController(Controller):
+    """Class Docstring Description
+    """
+
+    def show(self):
+        """Show a single resource listing
+        ex. Model.find('id')
+            Get().route("/show", UserResourceController)
+        """
+
+        return ''
+
+    def index(self):
+        """Show several resource listings
+        ex. Model.all()
+            Get().route("/index", UserResourceController)
+        """
+
+        return ''
+
+    def create(self):
+        """Show form to create new resource listings
+         ex. Get().route("/create", UserResourceController)
+        """
+
+        return ''
+
+    def store(self):
+        """Create a new resource listing
+        ex. Post target to create new Model
+            Post().route("/store", UserResourceController)
+        """
+
+        return ''
+
+    def edit(self):
+        """Show form to edit an existing resource listing
+        ex. Get().route("/edit", UserResourceController)
+        """
+
+        return ''
+
+    def update(self):
+        """Edit an existing resource listing
+        ex. Post target to update new Model
+            Post().route("/update", UserResourceController)
+        """
+
+        return ''
+
+    def destroy(self):
+        """Delete an existing resource listing
+        ex. Delete().route("/destroy", UserResourceController)
+        """
+
+        return ''

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -675,3 +675,17 @@ class RouteGroup:
         for route in self.routes:
             if isinstance(route.named_route, str):
                 route.named_route = name + route.named_route
+
+
+class Resource:
+
+    def __new__(cls, base='', controller=''):
+        return [
+            Get("{}".format(base), "{}@index".format(controller)),
+            Get("{}/create".format(base), "{}@create".format(controller)),
+            Post("{}".format(base), "{}@store".format(controller)),
+            Get("{}/@id".format(base), "{}@show".format(controller)),
+            Get("{}/@id/edit".format(base), "{}@edit".format(controller)),
+            Match(['PUT', 'PATCH']).route("{}/@id".format(base), "{}@update".format(controller)),
+            Delete("{}/@id".format(base), "{}@destroy".format(controller)),
+        ]

--- a/masonite/routes.py
+++ b/masonite/routes.py
@@ -679,13 +679,43 @@ class RouteGroup:
 
 class Resource:
 
-    def __new__(cls, base='', controller=''):
-        return [
-            Get("{}".format(base), "{}@index".format(controller)),
-            Get("{}/create".format(base), "{}@create".format(controller)),
-            Post("{}".format(base), "{}@store".format(controller)),
-            Get("{}/@id".format(base), "{}@show".format(controller)),
-            Get("{}/@id/edit".format(base), "{}@edit".format(controller)),
-            Match(['PUT', 'PATCH']).route("{}/@id".format(base), "{}@update".format(controller)),
-            Delete("{}/@id".format(base), "{}@destroy".format(controller)),
-        ]
+    def __new__(cls, base='', controller='', only=['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'], names={}):
+        routes = []
+        
+        if 'index' in only:
+            route = Get("{}".format(base), "{}@index".format(controller))
+            if 'index' in names:
+                route.name(names['index'])
+            routes.append(route)
+        if 'create' in only:
+            route = Get("{}/create".format(base), "{}@create".format(controller))
+            if 'create' in names:
+                route.name(names['create'])
+            routes.append(route)
+        if 'store' in only:
+            route = Post("{}".format(base), "{}@store".format(controller))
+            if 'store' in names:
+                route.name(names['store'])
+            routes.append(route)
+        if 'show' in only:
+            route = Get("{}/@id".format(base), "{}@show".format(controller))
+            if 'show' in names:
+                route.name(names['show'])
+            routes.append(route)
+        if 'edit' in only:
+            route = Get("{}/@id/edit".format(base), "{}@edit".format(controller))
+            if 'edit' in names:
+                route.name(names['edit'])
+            routes.append(route)
+        if 'update' in only:
+            route = Match(['PUT', 'PATCH']).route("{}/@id".format(base), "{}@update".format(controller))
+            if 'update' in names:
+                route.name(names['update'])
+            routes.append(route)
+        if 'destroy' in only:
+            route = Delete("{}/@id".format(base), "{}@destroy".format(controller))
+            if 'destroy' in names:
+                route.name(names['destroy'])
+            routes.append(route)
+        
+        return routes

--- a/masonite/testing/MockRoute.py
+++ b/masonite/testing/MockRoute.py
@@ -20,6 +20,12 @@ class MockRoute:
     def hasController(self, controller):
         return self.route.controller == controller
 
+    def assertHasController(self, controller):
+        if isinstance(controller, str) and '@' in controller:
+            controller, method = controller.split('@')
+            assert self.route.controller.__name__ == controller, "Controller is {}. Asserted {}".format(self.route.controller.__name__, controller)
+            assert self.route.controller_method == method, "Controller method is {}. Asserted {}".format(self.route.controller_method, method)
+
     def contains(self, value):
         return value in self.container.make('Response')
 

--- a/masonite/testing/MockRoute.py
+++ b/masonite/testing/MockRoute.py
@@ -11,6 +11,14 @@ class MockRoute:
         self.container = container
         self.wsgi = wsgi
 
+    def assertIsNamed(self, name):
+        assert self.route.named_route == name, "Route name is {}. Asserted {}".format(self.route.named_route, name)
+        return self
+
+    def assertIsNotNamed(self):
+        assert self.route.named_route == None, "Route has a name: {}".format(self.route.named_route)
+        return self
+
     def isNamed(self, name):
         return self.route.named_route == name
 
@@ -25,6 +33,8 @@ class MockRoute:
             controller, method = controller.split('@')
             assert self.route.controller.__name__ == controller, "Controller is {}. Asserted {}".format(self.route.controller.__name__, controller)
             assert self.route.controller_method == method, "Controller method is {}. Asserted {}".format(self.route.controller_method, method)
+
+        return self
 
     def contains(self, value):
         return value in self.container.make('Response')

--- a/tests/core/test_routes.py
+++ b/tests/core/test_routes.py
@@ -6,7 +6,7 @@ from masonite.exceptions import InvalidRouteCompileException, RouteException
 from masonite.helpers.routes import create_matchurl, flatten_routes, group
 from masonite.request import Request
 from masonite.routes import (Connect, Delete, Get, Head, Match, Options, Patch,
-                             Post, Put, Redirect, Route, RouteGroup, Trace)
+                             Post, Put, Redirect, Resource, Route, RouteGroup, Trace)
 from masonite.testing import TestCase
 from masonite.testsuite.TestSuite import generate_wsgi
 
@@ -301,6 +301,22 @@ class TestOptionalRoutes(TestCase):
         self.assertEqual(request.route('user.multiple', {'name': 'john'}), '/multiple/user/john')
         self.assertEqual(request.route('user.multiple', {'name': 'john', 'last': 'smith'}), '/multiple/user/john/smith')
         self.assertEqual(request.route('user.multiple', {'last': 'smith'}), '/multiple/user/smith')
+
+class TestRouteResources(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.routes(only=[Resource('/user', 'UserResourceController')])
+
+    def test_has_correct_controllers(self):
+        self.get('/user').assertHasController('UserResourceController@index')
+        self.get('/user/create').assertHasController('UserResourceController@create')
+        self.post('/user').assertHasController('UserResourceController@store')
+        self.get('/user/1').assertHasController('UserResourceController@show')
+        self.get('/user/1/edit').assertHasController('UserResourceController@edit')
+        self.put('/user/1').assertHasController('UserResourceController@update')
+        self.delete('/user/1').assertHasController('UserResourceController@destroy')
+
 
 class WsgiInputTestClass:
 

--- a/tests/core/test_routes.py
+++ b/tests/core/test_routes.py
@@ -306,16 +306,18 @@ class TestRouteResources(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.routes(only=[Resource('/user', 'UserResourceController')])
+        self.routes(only=[Resource('/user', 'UserResourceController', names={
+            'create': 'users.build'
+        })])
 
     def test_has_correct_controllers(self):
-        self.get('/user').assertHasController('UserResourceController@index')
-        self.get('/user/create').assertHasController('UserResourceController@create')
-        self.post('/user').assertHasController('UserResourceController@store')
-        self.get('/user/1').assertHasController('UserResourceController@show')
-        self.get('/user/1/edit').assertHasController('UserResourceController@edit')
-        self.put('/user/1').assertHasController('UserResourceController@update')
-        self.delete('/user/1').assertHasController('UserResourceController@destroy')
+        self.get('/user').assertHasController('UserResourceController@index').assertIsNotNamed()
+        self.get('/user/create').assertHasController('UserResourceController@create').assertIsNamed('users.build')
+        self.post('/user').assertHasController('UserResourceController@store').assertIsNotNamed()
+        self.get('/user/1').assertHasController('UserResourceController@show').assertIsNotNamed()
+        self.get('/user/1/edit').assertHasController('UserResourceController@edit').assertIsNotNamed()
+        self.put('/user/1').assertHasController('UserResourceController@update').assertIsNotNamed()
+        self.delete('/user/1').assertHasController('UserResourceController@destroy').assertIsNotNamed()
 
 
 class WsgiInputTestClass:


### PR DESCRIPTION
Can use this:

```python
from masonite.routes import Resource

ROUTES = [
    Resource('/base', 'UserController')
]
```

Can also add names:

```python
ROUTES = [
    Resource('/base', 'UserController', names={
        'create': 'base.build'
    })
]
```

and define only a certain number of routes:

```python
from masonite.routes import Resource

ROUTES = [
    Resource('/base', 'UserController', only=['create', 'index', 'show'])
]
```

This will generate several routes and maps to the routes found here: #404

Closes #404 